### PR TITLE
TextColor.cs: fix displaying wrong color for message with irc color

### DIFF
--- a/ZeroKLobby/Config.cs
+++ b/ZeroKLobby/Config.cs
@@ -65,6 +65,7 @@ namespace ZeroKLobby
 
         [Category("Chat")]
         [DisplayName("Color: Background")]
+        [Description("Background color for chat window and playerlist")]
         [XmlIgnore]
         public Color BgColor {
             get { return Color.FromArgb(BgColorInt); }

--- a/ZeroKLobby/MicroLobby/ChatControl.cs
+++ b/ZeroKLobby/MicroLobby/ChatControl.cs
@@ -62,9 +62,6 @@ namespace ZeroKLobby.MicroLobby
             playerBox.BackColor = Program.Conf.BgColor;
             playerBox.ForeColor = Program.Conf.TextColor;
 
-            sendBox.BackColor = Program.Conf.BgColor;
-            sendBox.ForeColor = Program.Conf.TextColor;
-
             playerSearchBox.BackColor = Program.Conf.BgColor;
             playerSearchBox.ForeColor = Program.Conf.TextColor;
 
@@ -86,6 +83,8 @@ namespace ZeroKLobby.MicroLobby
             ChatBox.MouseDown += chatBox_MouseDown;
             ChatBox.MouseMove += chatBox_MouseMove;
             ChatBox.FocusInputRequested += (s, e) => GoToSendBox();
+            ChatBox.ChatBackgroundColor = TextColor.background; //same as Program.Conf.BgColor but TextWindow.cs need this.
+            ChatBox.IRCForeColor = 14; //mirc grey. Unknown use
 
             Program.TasClient.ChannelUserAdded += client_ChannelUserAdded;
             Program.TasClient.ChannelUserRemoved += client_ChannelUserRemoved;
@@ -100,7 +99,8 @@ namespace ZeroKLobby.MicroLobby
             Program.TasClient.JoinedChannels.TryGetValue(ChannelName, out channel);
 
             //Topic Box that displays over the channel
-            topicBox.ChatBackgroundColor = 15; //gray
+            topicBox.IRCForeColor = 14; //mirc grey. Unknown use
+            topicBox.ChatBackgroundColor = TextColor.topicBackground;
             topicBox.HorizontalScroll.Enabled = true;
             topicBox.BorderStyle = BorderStyle.FixedSingle;
             topicBox.VerticalScroll.Visible = false;

--- a/ZeroKLobby/MicroLobby/PrivateMessageControl.Designer.cs
+++ b/ZeroKLobby/MicroLobby/PrivateMessageControl.Designer.cs
@@ -28,21 +28,20 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.sendBox1 = new SendBox();
+            this.sendBox = new SendBox();
             this.ChatBox = new ChatBox();
             this.SuspendLayout();
             // 
-            // sendBox1
+            // sendBox
             // 
-            this.sendBox1.AcceptsTab = true;
-            this.sendBox1.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.sendBox1.Location = new System.Drawing.Point(0, 389);
-            this.sendBox1.Multiline = true;
-            this.sendBox1.Name = "sendBox1";
-            this.sendBox1.Size = new System.Drawing.Size(455, 20);
-            this.sendBox1.TabIndex = 0;
-            this.sendBox1.PreviewKeyDown += new System.Windows.Forms.PreviewKeyDownEventHandler(this.sendBox1_PreviewKeyDown);
-            this.sendBox1.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.sendBox1_KeyPress);
+            this.sendBox.AcceptsTab = true;
+            this.sendBox.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.sendBox.Location = new System.Drawing.Point(0, 389);
+            this.sendBox.Multiline = true;
+            this.sendBox.Name = "sendBox";
+            this.sendBox.Size = new System.Drawing.Size(455, 20);
+            this.sendBox.TabIndex = 0;
+            this.sendBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.sendBox_KeyDown);
             // 
             // chatBox
             // 
@@ -58,7 +57,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.ChatBox);
-            this.Controls.Add(this.sendBox1);
+            this.Controls.Add(this.sendBox);
             this.Name = "PrivateMessageControl";
             this.Size = new System.Drawing.Size(455, 409);
             this.ResumeLayout(false);
@@ -68,7 +67,7 @@
 
         #endregion
 
-        private SendBox sendBox1;
+        private SendBox sendBox;
         public ChatBox ChatBox { get; set; }
     }
 }

--- a/ZeroKLobby/MicroLobby/SendBox.cs
+++ b/ZeroKLobby/MicroLobby/SendBox.cs
@@ -26,7 +26,10 @@ namespace ZeroKLobby.MicroLobby
         public SendBox()
         {
             Multiline = true;
+            WordWrap = false; //long text continue to the right instead of appearing in new line
             this.Font = Program.Conf.ChatFont;
+            this.BackColor = Program.Conf.BgColor;
+            this.ForeColor = Program.Conf.TextColor;
         }
 
         protected override void OnKeyPress(KeyPressEventArgs e)
@@ -204,6 +207,12 @@ namespace ZeroKLobby.MicroLobby
             }
             Select(prevSpacePos + 1, SelectionStart - prevSpacePos - 1);
             SelectedText = "";
+        }
+
+        internal void InsertColorCharacter()
+        {
+            Text = Text.Insert(SelectionStart + SelectionLength, "\x03");
+            Text = Text.Insert(SelectionStart, "\x0301,00");
         }
     }
 }

--- a/ZeroKLobby/MicroLobby/ServerTab.cs
+++ b/ZeroKLobby/MicroLobby/ServerTab.cs
@@ -47,6 +47,9 @@ namespace ZeroKLobby.MicroLobby
                     }
                     prevVis = Visible;
                 };
+
+            textBox.ChatBackgroundColor = TextColor.background; //same as Program.Conf.BgColor but TextWindow.cs need this.
+            textBox.IRCForeColor = 14; //mirc grey. Unknown use
         }
 
         public string PathHead { get { return "server"; } }

--- a/ZeroKLobby/MicroLobby/TextColor.cs
+++ b/ZeroKLobby/MicroLobby/TextColor.cs
@@ -6,58 +6,74 @@ namespace ZeroKLobby.MicroLobby
 {
     public static class TextColor
     {
-        const int args = 2;
-        public static readonly string Args = ColorChar + args.ToString("00");
-        const int background = 0;
-        public static readonly string Background = ColorChar + background.ToString("00");
-        const char boldChar = (char)2; // not implemented
-        public const char ColorChar = (char)3;
-        const int date = 3;
-        public static readonly string Date = ColorChar + date.ToString("00");
-        const int emote = 4;
-        public static readonly string Emote = ColorChar + emote.ToString("00");
-        const int error = 5;
-        public static readonly string Error = ColorChar + error.ToString("00");
-        const int history = 6;
-        public static readonly string History = ColorChar + history.ToString("00");
-        const int incomingCommand = 7;
-        public static readonly string IncomingCommand = ColorChar + incomingCommand.ToString("00");
-        const int join = 8;
-        public static readonly string Join = ColorChar + join.ToString("00");
-        const int leave = 9;
-        public static readonly string Leave = ColorChar + leave.ToString("00");
-        const int link = 10;
-        public static readonly string Link = ColorChar + link.ToString("00");
-        const int message = 11;
-        public static readonly string Message = ColorChar + message.ToString("00");
-        const int outgoingCommand = 12;
-        public static readonly string OutgoingCommand = ColorChar + outgoingCommand.ToString("00");
-        const char plainChar = (char)15;
-        const char reverseChar = (char)22;
-        const int text = 1;
-        public static readonly string Text = ColorChar + text.ToString("00");
-        const int topic = 14;
-        public static readonly string Topic = ColorChar + topic.ToString("00");
-        const int topicBackground = 15;
-        public static readonly string TopicBackground = ColorChar + topicBackground.ToString("00");
+        public const int ircColorOffset = 16; //15 color reserved for mirc standard color
+        public const int args = ircColorOffset + 2;
+        public const int background = ircColorOffset + 0;
+        public const char boldChar = (char)2; // not implemented
+        public const char ColorChar = (char)3; //&#x3 or \x003
+        public const int date = ircColorOffset + 3;
+        public const int emote = ircColorOffset + 4;
+        public const int error = ircColorOffset + 5;
+        public const int history = ircColorOffset + 6;
+        public const int incomingCommand = ircColorOffset + 7;
+        public const int join = ircColorOffset + 8;
+        public const int leave = ircColorOffset + 9;
+        public const int link = ircColorOffset + 10;
+        public const int message = ircColorOffset + 11;
+        public const int outgoingCommand = ircColorOffset + 12;
+        public const char plainChar = (char)15;
+        public const char reverseChar = (char)22;
+        public const int text = ircColorOffset + 1;
+        public const int topic = ircColorOffset + 14;
+        public const int topicBackground = ircColorOffset + 15;
         public const char NewColorChar = '\xFF03';
         public const char UnderlineChar = (char)31;
         public const char UrlEnd = '\xFF0C';
         public const char UrlStart = '\xFF0B';
         public const char EmotChar = '\xFF0A';
-        const int username = 13;
+        public const int username = ircColorOffset + 13;
+        public static readonly string Args = ColorChar + args.ToString("00");
+        public static readonly string Background = ColorChar + background.ToString("00");
+        public static readonly string Date = ColorChar + date.ToString("00");
+        public static readonly string Emote = ColorChar + emote.ToString("00");
+        public static readonly string Error = ColorChar + error.ToString("00");
+        public static readonly string History = ColorChar + history.ToString("00");
+        public static readonly string IncomingCommand = ColorChar + incomingCommand.ToString("00");
+        public static readonly string Join = ColorChar + join.ToString("00");
+        public static readonly string Leave = ColorChar + leave.ToString("00");
+        public static readonly string Link = ColorChar + link.ToString("00");
+        public static readonly string Message = ColorChar + message.ToString("00");
+        public static readonly string OutgoingCommand = ColorChar + outgoingCommand.ToString("00");
+        public static readonly string Text = ColorChar + text.ToString("00");
+        public static readonly string Topic = ColorChar + topic.ToString("00");
+        public static readonly string TopicBackground = ColorChar + topicBackground.ToString("00");
         public static readonly string Username = ColorChar + username.ToString("00");
-
-        static Regex allCodesExceptEmot = new Regex("\xFF03[0-9]{4}|\xFF0B|\xFF0C|\x3\\d{2},\\d{2}|\x3\\d{2}");
-        static Regex allCodes = new Regex("\xFF03[0-9]{4}|\xFF0B|\xFF0C|\x3\\d{2},\\d{2}|\x3\\d{2}|\xFF0A\\d{3}|\xFF0A");
-        static Regex codes = new Regex("\xFF03[0-9]{4}|\x3\\d{2},\\d{2}|\x3\\d{2}");
+        static Regex allCodesExceptEmot = new Regex("\xFF03[0-9]{4}|\xFF0B|\xFF0C|\x3\\d{2},\\d{2}|\x3\\d{2}|\x3");
+        static Regex allCodes = new Regex("\xFF03[0-9]{4}|\xFF0B|\xFF0C|\x3\\d{2},\\d{2}|\x3\\d{2}|\x3|\xFF0A\\d{3}|\xFF0A");
+        static Regex codes = new Regex("\xFF03[0-9]{4}|\x3\\d{2},\\d{2}|\x3\\d{2}|\x3");
         static Color[] colors;
+        public const int colorRange = 16 + ircColorOffset;
 
 
         static TextColor()
         {
-            colors = new Color[16]; //be to increment this when adding colors
-
+            colors = new Color[colorRange]; //be sure to increment this when adding colors
+            colors[0] = Color.FromArgb(255, 255, 255); //white, see https://github.com/myano/jenni/wiki/IRC-String-Formatting and http://www.w3schools.com/html/html_colornames.asp
+            colors[1] = Color.FromArgb(0, 0, 0); //black
+            colors[2] = Color.FromArgb(0, 0, 255); //blue
+            colors[3] = Color.FromArgb(0, 128, 0); //green
+            colors[4] = Color.FromArgb(255, 0, 0); //red
+            colors[5] = Color.FromArgb(165, 42, 42); //brown
+            colors[6] = Color.FromArgb(128, 0, 128); //purple
+            colors[7] = Color.FromArgb(255, 165, 0); //orange
+            colors[8] = Color.FromArgb(255, 255, 0); //yellow
+            colors[9] = Color.FromArgb(144, 238, 144); //light green
+            colors[10] = Color.FromArgb(0, 128, 128); //teal
+            colors[11] = Color.FromArgb(224, 255, 255); //light cyan
+            colors[12] = Color.FromArgb(173, 216, 230); //light blue 
+            colors[13] = Color.FromArgb(255, 192, 203); //pink 
+            colors[14] = Color.FromArgb(128, 128, 128); //grey
+            colors[15] = Color.FromArgb(211, 211, 211); //light grey
             colors[background] = Program.Conf.BgColor;
             colors[text] = Program.Conf.TextColor;
             colors[args] = Program.Conf.TextColor;

--- a/ZeroKLobby/MicroLobby/TextWindow.cs
+++ b/ZeroKLobby/MicroLobby/TextWindow.cs
@@ -431,7 +431,8 @@ namespace ZeroKLobby.MicroLobby
                 else if (unreadMarker > 0) unreadMarker++;
 
                 newLine = newLine.Replace("\n", " ");
-                newLine = newLine.Replace("&#x3;", TextColor.ColorChar.ToString());
+                newLine = newLine.Replace("&#x3;", TextColor.ColorChar.ToString()); //color start. &#x3 is 0x003
+                newLine = newLine.Replace("&#x3", TextColor.ColorChar.ToString()); //color end
                 newLine = ParseUrl(newLine);
 
                 //get the color from the line
@@ -969,16 +970,16 @@ namespace ZeroKLobby.MicroLobby
                                                     curForeColor = Convert.ToInt32(line.ToString().Substring(1, 2));
                                                     curBackColor = Convert.ToInt32(line.ToString().Substring(3, 2));
 
-                                                    //check to make sure that FC and BC are in range 0-31
-                                                    if (curForeColor > 31) curForeColor = displayLines[curLine].TextColor;
-                                                    if (curBackColor > 31) curBackColor = backColor;
+                                                    //check to make sure that FC and BC are in range 0-32
+                                                    if (curForeColor > TextColor.colorRange) curForeColor = displayLines[curLine].TextColor;
+                                                    if (curBackColor > TextColor.colorRange) curBackColor = backColor;
                                                 }
                                                 else //if highlighting then:
                                                 {
                                                     pastForeColor = Convert.ToInt32(line.ToString().Substring(1, 2)); //remember what color this text suppose to be (will be restored to the text on the right if highlighting only happen to text on the left) 
                                                     
-                                                    //check to make sure that FC and BC are in range 0-31
-                                                    if (pastForeColor > 31) pastForeColor = displayLines[curLine].TextColor; //only happen on exceptional case (this is only for safety, no significant whatsoever)
+                                                    //check to make sure that FC and BC are in range 0-32
+                                                    if (pastForeColor > TextColor.colorRange) pastForeColor = displayLines[curLine].TextColor; //only happen on exceptional case (this is only for safety, no significant whatsoever)
                                                 }
 
                                                 //remove the color codes from the string
@@ -1053,8 +1054,8 @@ namespace ZeroKLobby.MicroLobby
                                                     if (highlight)
                                                     {
                                                         pastForeColor = curForeColor; //remember previous text color
-                                                        curForeColor = 0; //white (defined in TextColor.cs)
-                                                        curBackColor = 2; //black (defined in TextColor.cs)
+                                                        curForeColor = TextColor.background; //white (defined in TextColor.cs)
+                                                        curBackColor = TextColor.text; //black (defined in TextColor.cs)
                                                     }
                                                     else
                                                     {

--- a/ZeroKLobby/NavigationControl.cs
+++ b/ZeroKLobby/NavigationControl.cs
@@ -81,29 +81,29 @@ namespace ZeroKLobby
 
             ButtonList = new List<ButtonInfo>() //normal arrangement
             {
-                new ButtonInfo() { Label = "HOME", TargetPath = "http://zero-k.info/", Icon= Buttons.home, Height = 32,},
-                new ButtonInfo() { Label = "CHAT", TargetPath = "chat", Icon= ZklResources.chat, Height = 32, },
+                new ButtonInfo() { Label = "HOME", TargetPath = "http://zero-k.info/", Icon= Buttons.home, Height = 32,Width = 80 },
+                new ButtonInfo() { Label = "CHAT", TargetPath = "chat", Icon= ZklResources.chat, Height = 32, Width = 65 },
                 new ButtonInfo()
                 {
                     Label = "SINGLEPLAYER",
                     TargetPath = "http://zero-k.info/Missions",
                     Icon = Buttons.spherebot,
-                    Width = 128,
+                    Width = 125,
                     Height = 32,
                 },
                 new ButtonInfo()
                 {
                     Label = "MULTIPLAYER",
                     TargetPath = "battles", Icon =  ZklResources.battle,
-                    Width = 128,
+                    Width = 115,
                     Height = 32,
                 },
                 
                 //new ButtonInfo() { Label = "PLANETWARS", TargetPath = "http://zero-k.info/Planetwars", Height = 32,  },
-                new ButtonInfo() { Label = "MAPS", TargetPath = "http://zero-k.info/Maps", Icon = Buttons.map, Height = 32,  },
-                new ButtonInfo() { Label = "REPLAYS", TargetPath = "http://zero-k.info/Battles", Icon = Buttons.video_icon, Height = 32, },
-                new ButtonInfo() { Label = "FORUM", TargetPath = "http://zero-k.info/Forum", Height = 32, },
-                new ButtonInfo() { Label = "SETTINGS", TargetPath = "settings", Icon = Buttons.settings, Height = 32, Dock = DockStyle.Right},
+                new ButtonInfo() { Label = "MAPS", TargetPath = "http://zero-k.info/Maps", Icon = Buttons.map, Height = 32, Width = 75 },
+                new ButtonInfo() { Label = "REPLAYS", TargetPath = "http://zero-k.info/Battles", Icon = Buttons.video_icon, Height = 32, Width = 95 },
+                new ButtonInfo() { Label = "FORUM", TargetPath = "http://zero-k.info/Forum", Height = 32, Width = 65, },
+                new ButtonInfo() { Label = "SETTINGS", TargetPath = "settings", Icon = Buttons.settings, Height = 32, Width = 100, Dock = DockStyle.Right},
                
             };
 

--- a/ZeroKLobby/Notifications/BattleBar.cs
+++ b/ZeroKLobby/Notifications/BattleBar.cs
@@ -42,6 +42,9 @@ namespace ZeroKLobby.Notifications
         internal BattleBar() {
             InitializeComponent();
 
+            picoChat.ChatBackgroundColor = TextColor.background; //same color as Program.Conf.BgColor
+            picoChat.IRCForeColor = 14; //mirc grey. Unknown use
+
             Program.ToolTip.SetText(cbQm, "Enable or disable QuickMatch");
             Program.ToolTip.SetText(cbSide, "Choose the faction you wish to play.");
 


### PR DESCRIPTION
(color for irc was used for theme, moved them to fix overlap)

PrivateMessageControl.cs: fix autocomplete username not working in PM, also make background theme effect PM (and ServerTab.cs & Battlebar.cs) area too.

ChatControl.cs & BattleBar.cs: some required tweak for irc color changes.

SendBox.cs: overflowing text now grow to the right rather than wordWraped to new line (for intuitiveness)

TextWindow.cs: capture closing IRC color char

NavigationControl.cs: make button fit the Text size (make it smaller)
