### PR TITLE
Add timestamp to forum posts

### DIFF
--- a/Zero-K.info/Views/Forum/PostList.cshtml
+++ b/Zero-K.info/Views/Forum/PostList.cshtml
@@ -24,7 +24,8 @@
                         </td>
                         <td valign='top'>
                             @Html.PrintAccount(p.Account)<br />
-                            <small>@p.Created.ToAgoString()
+                            <small>@p.Created.AddTicks( - (p.Created.Ticks % TimeSpan.TicksPerSecond))<br />
+                                @p.Created.ToAgoString()
                                 @if (p.ForumPostEdits.Any())
                                 {
                                     var lastEdit = p.ForumPostEdits.OrderByDescending(x => x.EditTime).First();


### PR DESCRIPTION
So you know exactly what time (UTC) the post was created. This is in addition to the "how long ago" timespan currently shown.
