### PR TITLE
Print the full date in the chat history on chime.

### DIFF
--- a/ZeroKLobby/MicroLobby/HistoryManager.cs
+++ b/ZeroKLobby/MicroLobby/HistoryManager.cs
@@ -38,7 +38,10 @@ namespace ZeroKLobby.MicroLobby
                 var fileName = channelName + ".txt";
                 if (line is JoinLine || line is LeaveLine || line is HistoryLine || line is TopicLine) return;
                 Directory.CreateDirectory(historyFolder);
-                lock (locker) File.AppendAllText(Path.Combine(historyFolder, fileName), line.Text.StripAllCodes() + Environment.NewLine);
+                var lineStr = line is ChimeLine ? "*** " +
+                    ((ChimeLine)line).Date.ToString(System.Globalization.CultureInfo.CurrentCulture) :
+                    line.Text.StripAllCodes();
+                lock (locker) File.AppendAllText(Path.Combine(historyFolder, fileName), lineStr + Environment.NewLine);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
ZKL only prints the time in the chat log for every chime. That makes the log useless for any kind of temporal retrospection. This PR fixes that.
