### PR TITLE
Site login uses FirstOrDefault account in DB instead of SingleOrDefault

### DIFF
--- a/Zero-K.info/Controllers/HomeController.cs
+++ b/Zero-K.info/Controllers/HomeController.cs
@@ -191,7 +191,7 @@ namespace ZeroKWeb.Controllers
 		{
 			var db = new ZkDataContext();
 
-			var acc = db.Accounts.SingleOrDefault(x => x.Name == login && x.LobbyID != null);
+			var acc = db.Accounts.FirstOrDefault(x => x.Name == login && x.LobbyID != null);    // FIXME: might want to just not allow duplicate names to happen in the first place
 			if (acc == null) return Content("Invalid login name");
 			var hashed = Utils.HashLobbyPassword(password);
 			acc = AuthServiceClient.VerifyAccountHashed(login, hashed);


### PR DESCRIPTION
Prevents http://zero-k.info/Forum/Thread/7364#98980

It might be better to just prevent duplicate names in DB to begin with, but this might cause problems of its own if uberserver and ZK DBs desync for whatever reason...
