### PR TITLE
max-width for "Last battles" and "Posted threads"

### DIFF
--- a/Zero-K.info/Styles/style.css
+++ b/Zero-K.info/Styles/style.css
@@ -260,6 +260,13 @@ span.button_2text
     vertical-align:middle;
 }
 
+/* profile page
+----------------------------------------------*/
+div#features div#usr_recentbattles, div#features div#usr_forumposts
+{
+    max-width:302px;
+}
+
 /* galaxy map
 ----------------------------------------------*/
 .sectorgrid


### PR DESCRIPTION
Added a maximum width for the div elements that include the last ten battles played and the last ten threads that were posted in by the player. This is to stop "Posted threads" from being forced down and create a lot of empty space if a mapname of thread title is very long (see attachment).

Only has an effect in the default skin where the parent's width is known, not in the alternative skin used by ZKL that uses the full window.

![empty space](https://cloud.githubusercontent.com/assets/132906/3620590/d5a47588-0e02-11e4-983f-d16b826d73f9.png)
