### PR TITLE
BattleBar.cs: fix "ChangeMyBattleStatus" called twice each time "Play/Spec" radiobutton is pressed 

### DIFF
--- a/ZeroKLobby/Controls/MinimapFuncBox.cs
+++ b/ZeroKLobby/Controls/MinimapFuncBox.cs
@@ -62,14 +62,13 @@ namespace ZeroKLobby.Controls
             if (Program.TasClient.MyBattle != null)
             {
                 int freeAllyTeam;
-
+                bool iAmSpectator = Program.TasClient.MyBattleStatus.IsSpectator;
                 foreach (var allyTeam in ZeroKLobby.MicroLobby.ContextMenus.GetExistingTeams(out freeAllyTeam).Distinct())
                 {
-                    var at = allyTeam;
-                    if (allyTeam != Program.TasClient.MyBattleStatus.AllyNumber)
+                    if (iAmSpectator || allyTeam != Program.TasClient.MyBattleStatus.AllyNumber)
                     {
                         var item = new System.Windows.Forms.MenuItem("Join Team " + (allyTeam + 1));
-                        item.Click += (s, e2) => ActionHandler.JoinAllyTeam(at);
+                        item.Click += (s, e2) => ActionHandler.JoinAllyTeam(allyTeam);
                         menu.MenuItems.Add(item);
                     }
                 }

--- a/ZeroKLobby/MicroLobby/ContextMenus.cs
+++ b/ZeroKLobby/MicroLobby/ContextMenus.cs
@@ -432,7 +432,7 @@ namespace ZeroKLobby.MicroLobby
             var existingTeams = nonSpecs.GroupBy(p => p.AllyNumber).Select(team => team.Key).ToList();
             var botTeams = Program.TasClient.MyBattle.Bots.Select(bot => bot.AllyNumber);
             existingTeams.AddRange(botTeams.ToArray());
-            freeAllyTeam = Enumerable.Range(0, Int32.MaxValue).First(allyTeam => !existingTeams.Contains(allyTeam));
+            freeAllyTeam = Enumerable.Range(0, 100).First(allyTeam => !existingTeams.Contains(allyTeam));
             return existingTeams;
         }
 

--- a/ZeroKLobby/Notifications/BattleBar.cs
+++ b/ZeroKLobby/Notifications/BattleBar.cs
@@ -529,11 +529,11 @@ x => !b.Users.Any(y => y.AllyNumber == x.AllyID && y.TeamNumber == x.TeamID && !
 
         private void radioSpec_CheckedChanged(object sender, EventArgs e)
         {
-            if (!suppressSpecChange)
-            {
-                desiredSpectatorState = radioSpec.Checked;
-                client.ChangeMyBattleStatus(spectate: desiredSpectatorState);
-            }
+            //if (!suppressSpecChange) //NOTE: when "radioPlay" is checked/un-checked it already change status once.
+            //{
+            //    desiredSpectatorState = radioSpec.Checked;
+            //    client.ChangeMyBattleStatus(spectate: desiredSpectatorState);
+            //}
         }
     }
 


### PR DESCRIPTION
...(because "checkedChanged" event is called twice. Both button is a boolean and mutually exclusive, the state of other is a reverse of another, so only need to use 1 "checkedChanged" event)

ContextMenus.cs: lower the Enumerable.Range() (integer sequence generator) table size from Int32.MaxValue to 100 (for checking free allyteamID). For efficiency.

MinimapFuncBox.cs: fix a case of 1 allyteam number not appear in "Team" button (minimapFunction buttons, under playerlist) if you join that allyteam and then spec.
