### PR TITLE
Make ZKL remember previous window size & location and restore it upon restart

### DIFF
--- a/ZeroKLobby/Config.cs
+++ b/ZeroKLobby/Config.cs
@@ -310,6 +310,10 @@ namespace ZeroKLobby
         public bool UseMtEngine { get; set; }
         [Browsable(false)]
         public bool UseSafeMode { get; set; }
+        [Browsable(false)]
+        public Point windowLocation { get; set; }
+        [Browsable(false)]
+        public Size windowSize { get; set; }
         public Config() {}
 
         public static Config Load(string path) {

--- a/ZeroKLobby/MainWindow.cs
+++ b/ZeroKLobby/MainWindow.cs
@@ -98,6 +98,29 @@ namespace ZeroKLobby
                 Program.Downloader.DownloadAdded += TorrentManager_DownloadAdded;
                 timer1.Start();
             }
+            ReloadPosition();
+        }
+
+        private void ReloadPosition()
+        {
+			MinimumSize = new Size(200, 300); //so splitcontainer in SettingTab dont throw exception when pushed too close together
+            Size windowSize = Program.Conf.windowSize.IsEmpty ? Size : Program.Conf.windowSize; //Note: default MainWindow size is 1024x768 defined in MainWindow.Designer.cs
+            windowSize = new Size(Math.Min(SystemInformation.VirtualScreen.Width - 30, windowSize.Width),
+                           Math.Min(SystemInformation.VirtualScreen.Height - 30, windowSize.Height)); //in case user have less space than 1024x768
+            Point windowLocation = Program.Conf.windowLocation.IsEmpty ? DesktopLocation : Program.Conf.windowLocation;
+            windowLocation = new Point(Math.Min(SystemInformation.VirtualScreen.Width - Size.Width / 2, windowLocation.X),
+                                 Math.Min(SystemInformation.VirtualScreen.Height - Size.Height / 2, windowLocation.Y)); //in case user changed resolution
+            windowLocation = new Point(Math.Max(0 - Size.Width / 2, windowLocation.X),
+                                        Math.Max(0 - Size.Height / 2, windowLocation.Y));
+            StartPosition = FormStartPosition.Manual; //use manual to allow programmatic re-positioning
+            Size = windowSize;
+            DesktopLocation = windowLocation;
+        }
+        
+        private void SavePosition()
+        {
+            Program.Conf.windowSize = Size;
+            Program.Conf.windowLocation = DesktopLocation;
         }
 
         public void DisplayLog() {
@@ -317,6 +340,7 @@ namespace ZeroKLobby
             if (e.CloseReason == CloseReason.UserClosing) Program.CloseOnNext = true;
             if (Program.TasClient != null) Program.TasClient.Disconnect();
             Program.Conf.LastWindowState = WindowState;
+            SavePosition();
             Program.SaveConfig();
             WindowState = FormWindowState.Minimized;
             systrayIcon.Visible = false;

--- a/ZeroKLobby/Program.cs
+++ b/ZeroKLobby/Program.cs
@@ -246,8 +246,6 @@ namespace ZeroKLobby
 
                 if (Conf.StartMinimized) MainWindow.WindowState = FormWindowState.Minimized;
                 else MainWindow.WindowState = FormWindowState.Normal;
-                MainWindow.Size = new Size( Math.Min(SystemInformation.VirtualScreen.Width-30, MainWindow.Width),
-                                            Math.Min(SystemInformation.VirtualScreen.Height-30, MainWindow.Height)); //in case user have less space than 1024x768
 
                 BattleBar = new BattleBar();
                 NewVersionBar = new NewVersionBar(SelfUpdater);


### PR DESCRIPTION
Config.cs: store location & size
MainWindow.cs: save position & size when closed and reload them when Initialized.
Program.cs: relocate a check-desktop-size-and-downsize-window-if-not-enough-space code to MainWindow.cs
