### PR TITLE
Don't say "Game over, exiting" several times after the battle ends

### DIFF
--- a/Springie/Springie/autohost/AutoHost.cs
+++ b/Springie/Springie/autohost/AutoHost.cs
@@ -833,26 +833,16 @@ namespace Springie.autohost
 
         void spring_GameOver(object sender, SpringLogEventArgs e) {
             SayBattle("Game over, exiting");
+            // Spring sends GAMEOVER for every player and spec, we only need the first one.
+            spring.GameOver -= spring_GameOver;
             PlasmaShared.Utils.SafeThread(() =>
                 {
-                    Thread.Sleep(25000); // wait for stats
+                    // Wait for gadgets that send spring autohost messages after gadget:GameOver()
+                    // such as awards.lua
+                    Thread.Sleep(10000);
                     spring.ExitGame();
+                    spring.GameOver += spring_GameOver;
                 }).Start();
-
-            /*			try
-			{
-				var service = new ContentService();
-				service.GetRecommendedMap()
-
-			}
-
-			if (config.MapCycle.Length > 0)
-			{
-				mapCycleIndex = mapCycleIndex%config.MapCycle.Length;
-				SayBattle("changing to another map in mapcycle");
-				ComMap(TasSayEventArgs.Default, config.MapCycle[mapCycleIndex].Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries));
-				mapCycleIndex++;
-			}*/
         }
 
 


### PR DESCRIPTION
I'm sure you all noticed Springie saying "Game over, exiting" several times in a row after every battle. This change doesn't alter the behavior since it already treated the first GAMEOVER as the battle ending and just spawned redundant waiting threads.

I lowered the exit timeout to the original value since AFAIK in the end it had nothing to do with the replay saving bug and is only useful for gadgets sending stuff after gadget:GameOver(). 10 seconds is still too large IMO but more reasonable.
