### PR TITLE
spring.cs: add "Exception when trying to SayGame:" + what?

### DIFF
--- a/Shared/LobbyClient/Spring.cs
+++ b/Shared/LobbyClient/Spring.cs
@@ -236,7 +236,7 @@ namespace LobbyClient
                 talker.SendText(text);
             }
             catch (Exception e) {
-                Console.WriteLine("Exception when trying to SayGame");
+                Console.WriteLine("Exception when trying to SayGame:" + text);
             }
         }
 


### PR DESCRIPTION
might help with https://github.com/ZeroK-RTS/Zero-K-Infrastructure/issues/43 
could it be a spam that create out-of-memory? can't know if it doesn't echo what it tries to say.

will work better if we Deploy_springie immediately to get the benefit.
