### PR TITLE
Accept agreement: press "X" on accept agreement Form do nothing, if pressed "Accept" then accept agreement

### DIFF
--- a/ZeroKLobby/AcceptAgreementForm.cs
+++ b/ZeroKLobby/AcceptAgreementForm.cs
@@ -21,6 +21,7 @@ namespace ZeroKLobby
 
         void btnAgree_Click(object sender, EventArgs e)
         {
+            DialogResult = DialogResult.OK;
             Close();
         }
 

--- a/ZeroKLobby/Notifications/ConnectBar.cs
+++ b/ZeroKLobby/Notifications/ConnectBar.cs
@@ -67,15 +67,26 @@ namespace ZeroKLobby.Notifications
 				{
 					lbState.Text = "Waiting to accept agreement";
 					var acceptForm = new AcceptAgreementForm { AgreementText = e.Text };
-					acceptForm.ShowDialog();
-
-					client.AcceptAgreement();
-
-					PlasmaShared.Utils.SafeThread(() =>
+					if (acceptForm.ShowDialog() == DialogResult.OK)
+					{
+						lbState.Text = "Sending accept agreement";
+						client.AcceptAgreement();
+						PlasmaShared.Utils.SafeThread(() =>
 						{
 							Thread.Sleep(7000);
 							if (!Program.CloseOnNext) client.Login(Program.Conf.LobbyPlayerName, Program.Conf.LobbyPlayerPassword);
 						}).Start();
+					}
+					else
+					{
+						lbState.Text = "did not accept agreement";
+						PlasmaShared.Utils.SafeThread(() =>
+						{
+							Thread.Sleep(2000);
+							if (!Program.CloseOnNext) client.Disconnect(); //server will re-ask AcceptAgreement if we re-connect
+						}).Start();
+
+					}
 				};
 
 


### PR DESCRIPTION
In current deployed ZKL, pressing X will  accept agreement even when "Accept" button is plainly in sight. This is like being forced to accept.
When agreement is not accepted, the ConnectBar just disconnect, but allow a re-connect (which will re-ask the Accept Agreement).

Also
user could press Logout to login with different account since the button appear on top Navigation Bar
