### PR TITLE
MinimapFuncBox.cs: added Spring-AI to "AddAI" button

### DIFF
--- a/Shared/LobbyClient/Spring.cs
+++ b/Shared/LobbyClient/Spring.cs
@@ -43,7 +43,7 @@ namespace LobbyClient
         }
     };
 
-
+    [Serializable] //Serializable for saving as cache
     public class EngineConfigEntry
     {
         public string description { get; set; }
@@ -236,7 +236,7 @@ namespace LobbyClient
                 talker.SendText(text);
             }
             catch (Exception e) {
-                Console.WriteLine("Exception when trying to SayGame");
+                Console.WriteLine("Exception when trying to SayGame:" + text);
             }
         }
 

--- a/Shared/PlasmaShared/SpringScanner.cs
+++ b/Shared/PlasmaShared/SpringScanner.cs
@@ -103,7 +103,7 @@ namespace PlasmaShared
 
         readonly SpringPaths springPaths;
 
-        UnitSync unitSync;
+        public UnitSync unitSync;
 
         /// <summary>
         /// whether an attempt to load unitsync was performed
@@ -596,18 +596,7 @@ namespace PlasmaShared
 
             var info = GetUnitSyncData(workItem.CacheItem.FileName);
             //upon completion of any work: dispose unitsync. It can be re-initialize again later by VerifyUnitSync()
-            if (unitSync != null && GetWorkCost()<1)
-            {
-                try
-                {
-                    unitSync.Dispose();
-                    unitSync = null;
-                }
-                catch (Exception ex)
-                {
-                    Trace.TraceWarning("Error disposing unitsync: {0}", ex);
-                }
-            }
+            UnInitUnitsync();
             if (info != null)
             {
                 workItem.CacheItem.InternalName = info.Name;
@@ -674,6 +663,24 @@ namespace PlasmaShared
             return;
         }
 
+        /// <summary>UnInitUnitsync() check whether SpringScanner have any more mods/map to Unitsynced and call unitsync's UnInit() when there's no more work.
+        /// </summary>
+        public void UnInitUnitsync()
+        {
+            //upon completion of any work: dispose unitsync. It can be re-initialize again later by VerifyUnitSync()
+            if (unitSync != null && GetWorkCost() < 1)
+            {
+                try
+                {
+                    unitSync.Dispose();
+                    unitSync = null;
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceWarning("Error disposing unitsync: {0}", ex);
+                }
+            }
+        }
 
         void SaveCache()
         {
@@ -704,7 +711,9 @@ namespace PlasmaShared
             }
         }
 
-        void VerifyUnitSync()
+        /// <summary>VerifyUnitSync() check whether unitSync should be initialized and perform unitSync initialization.
+        /// </summary>
+        public void VerifyUnitSync()
         {
             if (unitSyncReInitCounter >= UnitSyncReInitFrequency)
             {

--- a/ZeroKLobby/MicroLobby/SpringStore.cs
+++ b/ZeroKLobby/MicroLobby/SpringStore.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using PlasmaDownloader;
+using PlasmaShared;
+using PlasmaShared.UnitSyncLib;
+using LobbyClient;
+
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+//using PlasmaShared.ContentService;
+
+namespace ZeroKLobby.MicroLobby
+{
+	/// <summary>
+	/// pre-computes Spring data that might be required in the gui
+	/// </summary>
+	class SpringStore
+	{
+		readonly object locker = new object();
+		List<Ai> Ais = new List<Ai>(10);
+        Dictionary<string,EngineConfigEntry> settingsOptions = null;
+        CacheFile cache = new CacheFile();
+        string cachePath = null;
+        bool loadedFile = false;
+
+		public string ChangedOptions { get; private set; }
+
+		public SpringStore()
+		{
+            Program.SpringPaths.SpringVersionChanged += (s, e) => SpringVersionChanged(s, e);
+		}
+
+        private void LoadCache()
+        {
+            SpringPaths springPaths = Program.SpringPaths;
+            cachePath = Utils.MakePath(springPaths.Cache, "SpringInfoCache.dat");
+            CacheFile loadedCache = null;
+            var serializer = new BinaryFormatter();
+            if (File.Exists(cachePath))
+            {
+                try
+                {
+                    using (var fs = File.OpenRead(cachePath)) loadedCache = (CacheFile)serializer.Deserialize(fs);
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceWarning("Warning: problem reading SpringInfo cache: {0}", ex);
+                    loadedCache = null;
+                }
+            }
+
+            if (loadedCache != null)
+            {
+                cache = loadedCache;
+                string springVersion = springPaths.SpringVersion;
+                if (springVersion != null)
+                {
+                    if (cache.springAiInfo.ContainsKey(springVersion))
+                        Ais = cache.springAiInfo[springVersion];
+                    if (cache.springSettingList.ContainsKey(springVersion))
+                        settingsOptions = cache.springSettingList[springVersion];
+                }
+            }
+        }
+
+        void SaveCache()
+        {
+            lock (cache)
+            {
+                try
+                {
+                    var saver = new BinaryFormatter();
+                    Directory.CreateDirectory(Path.GetDirectoryName(cachePath));
+                    using (var fs = File.OpenWrite(cachePath)) saver.Serialize(fs, cache);
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceError("Error saving SpringInfo cache: {0}", ex);
+                }
+            }
+        }
+
+        public List<Ai> GetSpringAis()
+        {
+            if (!loadedFile) //only load cache when being used
+            {
+                LoadCache();
+                loadedFile = true;
+            }
+
+            string springVersion = Program.SpringPaths.SpringVersion;
+            if (springVersion == null)
+                return Ais;
+
+            if (Ais.Count == 0 && cache.springAiInfo.ContainsKey(springVersion))
+                Ais = cache.springAiInfo[springVersion];
+
+            if (Ais.Count == 0)
+            {
+                if (Program.SpringScanner.UseUnitSync)
+                {
+                    Program.SpringScanner.VerifyUnitSync();
+                    if (Program.SpringScanner.unitSync != null)
+                    {
+                        Ais.Clear(); //reset count to 0
+                        foreach (var bot in Program.SpringScanner.unitSync.GetAis()) //IEnumberable can't be serialized, so convert to List. Ref: http://stackoverflow.com/questions/9102234/xmlserializer-in-c-sharp-wont-serialize-ienumerable
+                            Ais.Add(bot);
+                        cache.springAiInfo.Add(springVersion,Ais);
+                        Program.SpringScanner.UnInitUnitsync();
+                        SaveCache();
+                    }
+                }
+            }
+            return Ais;
+        }
+
+        public Dictionary<string, EngineConfigEntry> GetSpringSettings()
+        {
+            if (!loadedFile) //only load cache when being used
+            {
+                LoadCache();
+                loadedFile = true;
+            }
+
+            string springVersion = Program.SpringPaths.SpringVersion;
+            if (springVersion == null)
+                return settingsOptions;
+
+            if (settingsOptions == null && cache.springSettingList.ContainsKey(springVersion))
+                settingsOptions = cache.springSettingList[springVersion];
+
+            if (settingsOptions == null)
+            {
+                settingsOptions = new Spring(Program.SpringPaths).GetEngineConfigOptions();
+                cache.springSettingList.Add(springVersion, settingsOptions);
+                SaveCache();
+            }
+            return settingsOptions;
+        }
+
+        public void SpringVersionChanged(object sender, EventArgs e)
+        {
+            Ais.Clear();//reset count to 0
+            settingsOptions = null;
+        }
+
+
+        [Serializable]
+        class CacheFile
+        {
+            public readonly Dictionary<string, List<Ai>> springAiInfo = new Dictionary<string, List<Ai>>();
+            public readonly Dictionary<string, Dictionary<string, EngineConfigEntry>> springSettingList = new Dictionary<string, Dictionary<string, EngineConfigEntry>>();
+        }
+	}
+}

--- a/ZeroKLobby/MicroLobby/SpringsettingForm.cs
+++ b/ZeroKLobby/MicroLobby/SpringsettingForm.cs
@@ -74,7 +74,7 @@ namespace ZeroKLobby.MicroLobby
                 Program.ToolTip.SetText(cancelButton, "Exit, do not commit change");
                 Program.ToolTip.SetText(applyButton, "Write all entries to Springsettings.cfg");
 
-                settingsOptions = new Spring(Program.SpringPaths).GetEngineConfigOptions();
+                settingsOptions = Program.SpringStore.GetSpringSettings(); //using cache is 270 milisecond cheaper.  old: new Spring(Program.SpringPaths).GetEngineConfigOptions();
 
                 var location = 0;
                 foreach (var kvp in settingsOptions) //ref: http://www.dotnetperls.com/dictionary, http://stackoverflow.com/questions/10556205/deserializing-a-json-with-variable-name-value-pairs-into-object-in-c-sharp

--- a/ZeroKLobby/Program.cs
+++ b/ZeroKLobby/Program.cs
@@ -37,6 +37,7 @@ namespace ZeroKLobby
         public static JugglerBar JugglerBar { get; private set; }
         public static MainWindow MainWindow { get; private set; }
         public static ModStore ModStore { get; private set; }
+        public static SpringStore SpringStore { get; private set; }
         public static NotifySection NotifySection { get { return MainWindow.NotifySection; } }
         public static SayCommandHandler SayCommandHandler { get; private set; }
         public static SelfUpdater SelfUpdater { get; set; }
@@ -232,6 +233,7 @@ namespace ZeroKLobby
 
                 ConnectBar = new ConnectBar(TasClient);
                 ModStore = new ModStore();
+                SpringStore = new SpringStore();
                 ToolTip = new ToolTipHandler();
                 JugglerBar = new JugglerBar(TasClient);
                 BrowserInterop = new BrowserInterop(TasClient, Conf);
@@ -246,8 +248,6 @@ namespace ZeroKLobby
 
                 if (Conf.StartMinimized) MainWindow.WindowState = FormWindowState.Minimized;
                 else MainWindow.WindowState = FormWindowState.Normal;
-                MainWindow.Size = new Size( Math.Min(SystemInformation.VirtualScreen.Width-30, MainWindow.Width),
-                                            Math.Min(SystemInformation.VirtualScreen.Height-30, MainWindow.Height)); //in case user have less space than 1024x768
 
                 BattleBar = new BattleBar();
                 NewVersionBar = new NewVersionBar(SelfUpdater);

--- a/ZeroKLobby/ZeroKLobby.csproj
+++ b/ZeroKLobby/ZeroKLobby.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Controls\ZkSplitContainer.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="MicroLobby\SpringStore.cs" />
     <Compile Include="MicroLobby\HexToUnicodeConverter.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
Other files: Added SpringStore.cs, which cache Spring-AI because getting them from Unitsync repeatedly is super expensive! (UnitSync.cs interface might be guilty for this high cost, but that's for later).

SpringsettingForm.cs: also cached Springsetting list (only saved 270ms, but will never need to run Spring.exe to get the list)

The cache is refreshed for different spring. So tiny freeze should be expected when pressing "show Spring AI" for first time. 
