### PR TITLE
ToolTipForm.cs: make tooltip do not steal focus in Linux. 

### DIFF
--- a/ZeroKLobby/Notifications/NotifySection.cs
+++ b/ZeroKLobby/Notifications/NotifySection.cs
@@ -17,7 +17,7 @@ namespace SpringDownloader.Notifications
 		{
 			InitializeComponent();
 
-            timedUpdate.Interval = 50; //timer tick to add micro delay to Layout update.
+            timedUpdate.Interval =100; //timer tick to add micro delay to Layout update.
             timedUpdate.Tick += timedUpdate_Tick;
 		}
 

--- a/ZeroKLobby/ToolTips/ToolTipForm.cs
+++ b/ZeroKLobby/ToolTips/ToolTipForm.cs
@@ -19,6 +19,8 @@ namespace ZeroKLobby
                 var baseParams = base.CreateParams;
                 baseParams.ExStyle &= ~WS_EX_APPWINDOW;
                 baseParams.ExStyle |= WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
+				baseParams.Style &= ~WS_EX_APPWINDOW; //In MONO it seem to needed, not just add to ExtendedStyle
+                baseParams.Style |= WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
                 return baseParams;
             }
         }


### PR DESCRIPTION
Tooltip steal focus in Linux because the "WS_EX_NOACTIVATE" tag must be put to "STYLE" instead of in "ExSTYLE" (extended style)

NotifySection.cs: increase micro-delay for Chat layout-update. (because in Linux if multiple notification bar appears at same time  layout update doesn't appear to stack, so we add this delay to wait all of them appear first before doing layout update).
