### PR TITLE
User.cs & ScrollMessageFilter.cs: some tweak to make this 2 file compile on MonoDevelop

### DIFF
--- a/Shared/LobbyClient/User.cs
+++ b/Shared/LobbyClient/User.cs
@@ -25,10 +25,12 @@ namespace LobbyClient
         public int SpringieLevel = 1;
 
         string country;
-
+		
+		//This is only called once
         static User() {
             Assembly assembly = Assembly.GetAssembly(typeof(User));
-            var reader = new StreamReader(assembly.GetManifestResourceStream("Resources.CountryNames.txt"));
+			System.IO.Stream countryNames = assembly.GetManifestResourceStream(typeof(User), "Resources.CountryNames.txt"); //Note: GetManifestResourceStream with only 1 argument do not work in MonoDevelop
+            var reader = new StreamReader(countryNames);
 
             string line;
             while ((line = reader.ReadLine()) != null) {

--- a/ZeroKLobby/MicroLobby/ScrollMessageFilter.cs
+++ b/ZeroKLobby/MicroLobby/ScrollMessageFilter.cs
@@ -3,7 +3,13 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
-using mshtml;
+#if (!LINUX)
+using mshtml; 
+//will not compile in MonoDevelop
+//using preprocessor directive to skip. reference: http://msdn.microsoft.com/en-us/library/yt3yck0x.aspx
+//"LINUX" symbol is defined in LinuxDebug Project-option
+#endif
+
 
 namespace ZeroKLobby.MicroLobby
 {
@@ -20,17 +26,20 @@ namespace ZeroKLobby.MicroLobby
 
         public bool PreFilterMessage(ref Message m) {
             if (m.Msg == WM_MOUSEWHEEL) {
-                var delta = ((int)m.WParam >> 16);
                 var control = MainWindow.Instance.GetHoveredControl();
                 if (control != null) {
 
                     if (control is WebBrowser) {
-                        var brows = control as WebBrowser;
+						#if (!LINUX)
+						var brows = control as WebBrowser;
                         if (brows.Document != null) //check whether the page exist before adding a scroll bar
                         {
+
+						    var delta = ((int)m.WParam >> 16);
                             var htmlDoc = brows.Document.DomDocument as HTMLDocument;
                             if (htmlDoc != null) htmlDoc.parentWindow.scrollBy(0, -delta);
-                        }
+						}
+						#endif
                     }
                     else {
                         if (Environment.OSVersion.Platform == PlatformID.Unix) {


### PR DESCRIPTION
This only help a bit if someone tries soo hard to compile on MonoDevelop and use "LinuxDebug" build

There's other stuff that they will still need tweak if to compile on Mono-Develop,
1) tweak Zero-K.sln file header:
"Microsoft Visual Studio Solution File, Format Version 12.00
# Visual Studio 11"
into
"Microsoft Visual Studio Solution File, Format Version 11.00
# Visual Studio 2010"
https://bugzilla.xamarin.com/show_bug.cgi?id=4919

2)manually exclude TextToSpeech/SpeechRecognition files or put them  into separate module that compile/not-compile if Release/LinuxDebug  build option is used.

3) remove this line from ZeroKLobby.csproj : https://github.com/ZeroK-RTS/Zero-K-Infrastructure/blob/master/ZeroKLobby/ZeroKLobby.csproj#L8 (what this do?)
" <ProjectGuid>{AA5F8640-FBBC-4007-9589-6C7CD26D4867}</ProjectGuid> " ?
