### PR TITLE
User.cs: ops, undo compatibility for MonoDevelop because when compiled in VS it return Null during runtime

### DIFF
--- a/Shared/LobbyClient/User.cs
+++ b/Shared/LobbyClient/User.cs
@@ -29,7 +29,8 @@ namespace LobbyClient
 		//This is only called once
         static User() {
             Assembly assembly = Assembly.GetAssembly(typeof(User));
-			System.IO.Stream countryNames = assembly.GetManifestResourceStream(typeof(User), "Resources.CountryNames.txt"); //Note: GetManifestResourceStream with only 1 argument do not work in MonoDevelop
+            //Stream countryNames = assembly.GetManifestResourceStream(typeof(User), "Resources.CountryNames.txt"); //Fixme: GetManifestResourceStream with only 1 argument do not work in MonoDevelop
+            Stream countryNames = assembly.GetManifestResourceStream("Resources.CountryNames.txt");
             var reader = new StreamReader(countryNames);
 
             string line;


### PR DESCRIPTION
Compatibility for MonoDevelop seem to be really messy, maybe will need to store it in some fork (later) for easy sharing.
