### PR TITLE
AutoHost.cs: fix Springie do not spawn new room when "!spawn mod=zk:stable,title=test" command is called without map parameter.

### DIFF
--- a/Springie/Springie/MainConfig.cs
+++ b/Springie/Springie/MainConfig.cs
@@ -45,6 +45,13 @@ namespace Springie
 		public int RepoMasterRefresh { get { return 120; } }
 		public string PackageMasterUrl { get { return "http://repos.springrts.com/"; } }
 
+        //Note for testing, 
+        //1) Set "ClusterNode" to "alpha"
+        //2) Make sure AutoUpdater() wasn't run (in Program.cs),
+        //3) Compile Springie & run Springie.exe
+        //4) Login to server (as player) using Lobby, 
+        //5) Join a room called "KingRaptor Secret Clubhouse",
+        //6) Use "magic" for password.
 	    public MainConfig() {
             ClusterNode = "omega";
         }

--- a/Springie/Springie/autohost/AutoHost.cs
+++ b/Springie/Springie/autohost/AutoHost.cs
@@ -645,7 +645,7 @@ namespace Springie.autohost
 
             if (SpawnConfig != null) {
                 modname = SpawnConfig.Mod;
-                mapname = SpawnConfig.Map;
+                if (!String.IsNullOrEmpty(SpawnConfig.Map)) mapname = SpawnConfig.Map;
                 title = SpawnConfig.Title;
                 if (!String.IsNullOrEmpty(SpawnConfig.Password)) password = SpawnConfig.Password;
                 if (!String.IsNullOrEmpty(SpawnConfig.Engine))


### PR DESCRIPTION
this is what "Create new room" doing
