### PR TITLE
fix #169

### DIFF
--- a/Shared/LobbyClient/Spring.cs
+++ b/Shared/LobbyClient/Spring.cs
@@ -204,7 +204,6 @@ namespace LobbyClient
             return statsPlayers[name].IsIngameReady;
         }
 
-
         public void Kick(string name) {
             SayGame("/kick " + name);
         }
@@ -212,7 +211,6 @@ namespace LobbyClient
         public void ResignPlayer(string name) {
             if (IsRunning) talker.SendText(string.Format("/luarules resignteam {0}", name));
         }
-
 
         public void SayGame(string text) {
             try


### PR DESCRIPTION
- no more SayGame exception spam
- SayGame try-catch only catches the expected exception type
- axe away ugly copypasted /kills
- DEPLOY_SPRINGIE
