### PR TITLE
ZKL: some visual tweaks to startup menus (for first time user only)

### DIFF
--- a/ZeroKLobby/Program.cs
+++ b/ZeroKLobby/Program.cs
@@ -116,8 +116,8 @@ namespace ZeroKLobby
                 if (!SpringPaths.IsDirectoryWritable(StartupPath) || StartupPath.Contains("Local\\Apps")) {
                     MessageBox.Show(
                         string.Format(
-                            "Startup directory is not writable. \r\n Please use the newly created desktop icon to start Zero-K not the old one!\r\n Zero-K.exe will be moved to {0}",
-                            contentDir));
+                            "Please use the newly created desktop icon to start Zero-K not this one.\r\nZero-K.exe will be moved to {0}",
+                            contentDir),"Startup directory is not writable!");
                     var newTarget = Path.Combine(contentDir, "Zero-K.exe");
                     if (SelfUpdater.CheckForUpdate(newTarget, true)) {
                         Conf.Save(Path.Combine(contentDir, Config.ConfigFileName));

--- a/ZeroKLobby/SelectWritableFolder.Designer.cs
+++ b/ZeroKLobby/SelectWritableFolder.Designer.cs
@@ -30,8 +30,9 @@
         {
             this.tbFolder = new System.Windows.Forms.TextBox();
             this.lbDescription = new System.Windows.Forms.Label();
-            this.btnOk = new System.Windows.Forms.Button();
-            this.btnCancel = new System.Windows.Forms.Button();
+            this.btnOk = new ZeroKLobby.BitmapButton();
+            this.btnCancel = new ZeroKLobby.BitmapButton();
+            this.browseFolderbutton = new ZeroKLobby.BitmapButton();
             this.SuspendLayout();
             // 
             // tbFolder
@@ -57,7 +58,14 @@
             // btnOk
             // 
             this.btnOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnOk.Location = new System.Drawing.Point(86, 74);
+            this.btnOk.BackColor = System.Drawing.Color.Transparent;
+            this.btnOk.BackgroundImage = global::ZeroKLobby.Buttons.panel;
+            this.btnOk.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btnOk.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btnOk.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnOk.ForeColor = System.Drawing.Color.White;
+            this.btnOk.Location = new System.Drawing.Point(287, 74);
+            this.btnOk.Margin = new System.Windows.Forms.Padding(0);
             this.btnOk.Name = "btnOk";
             this.btnOk.Size = new System.Drawing.Size(75, 23);
             this.btnOk.TabIndex = 3;
@@ -68,8 +76,15 @@
             // btnCancel
             // 
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCancel.BackColor = System.Drawing.Color.Transparent;
+            this.btnCancel.BackgroundImage = global::ZeroKLobby.Buttons.panel;
+            this.btnCancel.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btnCancel.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(292, 74);
+            this.btnCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnCancel.ForeColor = System.Drawing.Color.White;
+            this.btnCancel.Location = new System.Drawing.Point(368, 74);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(0);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
             this.btnCancel.TabIndex = 4;
@@ -77,17 +92,38 @@
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
             // 
+            // browseFolderbutton
+            // 
+            this.browseFolderbutton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.browseFolderbutton.BackColor = System.Drawing.Color.Transparent;
+            this.browseFolderbutton.BackgroundImage = global::ZeroKLobby.Buttons.panel;
+            this.browseFolderbutton.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.browseFolderbutton.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.browseFolderbutton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.browseFolderbutton.ForeColor = System.Drawing.Color.White;
+            this.browseFolderbutton.Location = new System.Drawing.Point(15, 74);
+            this.browseFolderbutton.Margin = new System.Windows.Forms.Padding(0);
+            this.browseFolderbutton.Name = "browseFolderbutton";
+            this.browseFolderbutton.Size = new System.Drawing.Size(86, 23);
+            this.browseFolderbutton.TabIndex = 5;
+            this.browseFolderbutton.Text = "Browse Folder";
+            this.browseFolderbutton.UseVisualStyleBackColor = true;
+            this.browseFolderbutton.Click += new System.EventHandler(this.browseFolderbutton_Click);
+            // 
             // SelectWritableFolder
             // 
             this.AcceptButton = this.btnOk;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.DimGray;
             this.CancelButton = this.btnCancel;
             this.ClientSize = new System.Drawing.Size(455, 105);
+            this.Controls.Add(this.browseFolderbutton);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnOk);
             this.Controls.Add(this.lbDescription);
             this.Controls.Add(this.tbFolder);
+            this.ForeColor = System.Drawing.Color.White;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "SelectWritableFolder";
@@ -102,7 +138,8 @@
 
         private System.Windows.Forms.TextBox tbFolder;
         private System.Windows.Forms.Label lbDescription;
-        private System.Windows.Forms.Button btnOk;
-        private System.Windows.Forms.Button btnCancel;
+        private BitmapButton btnOk;
+        private BitmapButton btnCancel;
+        private BitmapButton browseFolderbutton;
     }
 }

--- a/ZeroKLobby/SelectWritableFolder.cs
+++ b/ZeroKLobby/SelectWritableFolder.cs
@@ -57,5 +57,17 @@ namespace ZeroKLobby
                 Close();
             }
         }
+
+        private void browseFolderbutton_Click(object sender, EventArgs e)
+        {
+            //copied from: http://stackoverflow.com/questions/13126008/how-can-i-get-path-folder-browser-dialog
+            using(var dialog = new FolderBrowserDialog())
+            {
+                if (dialog.ShowDialog() == DialogResult.OK)
+                {
+                    tbFolder.Text = dialog.SelectedPath;    
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
SelectWritableFolder Menu: buttons now adopt current ZKL theme and added "Browse Folder" button (so it won't look different than ZKL and the "Browse Folder" help so people don't need to copy-paste or edit the path string manually).

Program.cs: the message "Startup folder is not writable" is now displayed in Caption section of the error message instead of together with text message but empty caption. (resulting in more cleaner and compact message)
