### PR TITLE
Adds background/font color support for MULTIPLAYER

### DIFF
--- a/ZeroKLobby/MicroLobby/BattleListControl.cs
+++ b/ZeroKLobby/MicroLobby/BattleListControl.cs
@@ -46,7 +46,8 @@ namespace ZeroKLobby.MicroLobby
             InitializeComponent();
             AutoScroll = true;
             SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint | ControlStyles.DoubleBuffer, true);
-            BackColor = Color.White;
+            BackColor = Program.Conf.BgColor;
+            ForeColor = Program.Conf.TextColor;
             FilterText = Program.Conf.BattleFilter;
             Disposed += BattleListControl_Disposed;
             Program.BattleIconManager.BattleAdded += HandleBattle;


### PR DESCRIPTION
This change is **untested** because I have no idea about coding ZKL (tools to compile, etc.). What it should do is make the MULTIPLAYER tab use "Color: Background" and "Color: Default text" as specified in SETTINGS.
