### PR TITLE
increase rapid poll time to 20 minutes (part of #198)

### DIFF
--- a/ZeroKLobby/Config.cs
+++ b/ZeroKLobby/Config.cs
@@ -363,7 +363,7 @@ namespace ZeroKLobby
         }
 
         [Browsable(false)]
-        public int RepoMasterRefresh { get { return 120; } }
+        public int RepoMasterRefresh { get { return 1200; } }
 
 
         [Browsable(false)]


### PR DESCRIPTION
this heavily reduces server load. also the delay shouldn't hurt users / autohosts.
