### PR TITLE
Moves unlock-link to "Commanders" div

### DIFF
--- a/Zero-K.info/Views/Shared/UserDetail.cshtml
+++ b/Zero-K.info/Views/Shared/UserDetail.cshtml
@@ -200,8 +200,8 @@
     }
 
 
-    <div id="usr_technology" class="">
-        <h3>Technologies: </h3>
+    <div id="usr_commanders" class="">
+        <h3>Commanders: </h3>
 		
         @if (Model.AccountID == Global.AccountID) {
             <span title="You only get new points for unlocks after reaching the next level (Lvl: @(Model.Level + 1) with @(Account.GetXpForLevel(Model.Level + 1) - Account.GetXpForLevel(Model.Level)) XP)">
@@ -210,14 +210,10 @@
         }
         else {<text>@Model.Name can unlock technologies worth @Model.AvailableXP points</text>
         }
+        <br />
         <!--div>
             @Html.Partial("UnlockedTechnologies", Model.AccountUnlocks)
         </div-->
-    </div>
-
-    <div id="usr_commanders" class="">
-        <h3>Commanders: </h3>
-		
         @if (Model.AccountID == Global.AccountID) {
             <a href='@Url.Action("Commanders", "My")'>Configure Commanders</a>
         } 


### PR DESCRIPTION
This is because now all unlocks are commander modules and no longer "Technologies" for units. To clarify:

OLD
![commandersold](https://cloud.githubusercontent.com/assets/132906/4943693/fc2456d2-65f6-11e4-9697-48eac276fc8f.png)

NEW
![commandersnew](https://cloud.githubusercontent.com/assets/132906/4943699/08e8265a-65f7-11e4-955c-44267d3b9f6c.png)
