### PR TITLE
ZKL: full version of skasi's Multiplayer user colour fix...

### DIFF
--- a/ZeroKLobby/MicroLobby/BattleIcon.cs
+++ b/ZeroKLobby/MicroLobby/BattleIcon.cs
@@ -74,7 +74,8 @@ namespace ZeroKLobby.MicroLobby
     public bool IsServerManaged { get; private set; }
 
 
-      public static Brush TextBrush = new SolidBrush(Color.Black);
+      public static Brush TextBrush = new SolidBrush(Program.Conf.TextColor);
+      public static Brush BackBrush = new SolidBrush(Program.Conf.BgColor);
     public static Font TitleFont = new Font("Segoe UI", 8.25F, FontStyle.Bold);
 
     public BattleIcon(Battle battle)
@@ -193,12 +194,12 @@ namespace ZeroKLobby.MicroLobby
       RenderPlayers();
       int scaledWidth = DpiMeasurement.ScaleValueX(Width);
       int scaledHeight = DpiMeasurement.ScaleValueY(Height);
-      image = MakeSolidColorBitmap(Brushes.White, scaledWidth, scaledHeight);
+      image = MakeSolidColorBitmap(BackBrush, scaledWidth, scaledHeight);
       using (var g = Graphics.FromImage(image))
       {
         if (disposed)
         {
-            image = MakeSolidColorBitmap(Brushes.White, scaledWidth, scaledHeight);
+            image = MakeSolidColorBitmap(BackBrush, scaledWidth, scaledHeight);
           return;
         }
         if (finishedMinimap != null) g.DrawImageUnscaled(finishedMinimap, DpiMeasurement.ScaleValueX(3), DpiMeasurement.ScaleValueY(3));

--- a/ZeroKLobby/MicroLobby/BattleListControl.cs
+++ b/ZeroKLobby/MicroLobby/BattleListControl.cs
@@ -47,7 +47,6 @@ namespace ZeroKLobby.MicroLobby
             AutoScroll = true;
             SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint | ControlStyles.DoubleBuffer, true);
             BackColor = Program.Conf.BgColor;
-            ForeColor = Program.Conf.TextColor;
             FilterText = Program.Conf.BattleFilter;
             Disposed += BattleListControl_Disposed;
             Program.BattleIconManager.BattleAdded += HandleBattle;
@@ -60,7 +59,8 @@ namespace ZeroKLobby.MicroLobby
             hidePassworded = Program.Conf.HidePasswordedBattles;
             showOfficial = Program.Conf.ShowOfficialBattles;
 
-            FilterBattles();
+            FilterBattles(); //get list from BattleIconManager.cs
+            Sort();
             Invalidate();
         }
 

--- a/ZeroKLobby/MicroLobby/ToolTabs.cs
+++ b/ZeroKLobby/MicroLobby/ToolTabs.cs
@@ -16,6 +16,8 @@ namespace ZeroKLobby.MicroLobby
         readonly Panel panel = new Panel { Dock = DockStyle.Fill };
         readonly ToolStrip toolStrip = new ToolStrip
                                        {
+                                        BackColor = Program.Conf.BgColor,
+                                        ForeColor = Program.Conf.TextColor,
                                         Dock = DockStyle.Left,
                                         Stretch = false,
                                         GripStyle = ToolStripGripStyle.Hidden,
@@ -47,12 +49,8 @@ namespace ZeroKLobby.MicroLobby
 
         public ToolTabs()
         {
-            toolStrip.BackColor = Program.Conf.BgColor; //Color.White;
-            toolStrip.ForeColor = Program.Conf.TextColor;
-            panel.BackColor = Program.Conf.BgColor;
-            panel.ForeColor = Program.Conf.TextColor;
-            BackColor = Program.Conf.BgColor;
-            ForeColor = Program.Conf.TextColor;
+            var ovrflwBtn = toolStrip.OverflowButton;
+            ovrflwBtn.BackColor = Color.DimGray; //note: the colour of arrow on OverFlow button can't be set
             Controls.Add(panel);
             Controls.Add(toolStrip);
 


### PR DESCRIPTION
This version will fully do what skasi PR wanted to do. 

Also, 
I coloured ChatTab's overflow button (only appear if you have too many friend) with DimGrey colour, so that it is visible if user use either pure black or pure white background.

Also,
sorted BattleList when opened 1st time.

---

The merge conflict 
the conflict is just the 1 line in BattleListControl.cs,. I think there were no change, I only re-removed the unnecessary ForeColor because the item in BattleListControl.cs did not use it. Maybe only whitespace conflict, 

please use my PR over skasi original version. It will work.
