### PR TITLE
ZKL: make tooltip able to appear on multiple ZKL window ...

### DIFF
--- a/ZeroKLobby/MainWindow.cs
+++ b/ZeroKLobby/MainWindow.cs
@@ -141,12 +141,20 @@ namespace ZeroKLobby
         }
 
         public Control GetHoveredControl() {
+            //fore control
             var lastForm = Application.OpenForms.OfType<Form>().LastOrDefault(x => !(x is ToolTipForm) && x.Visible);
             if (lastForm != null) {
                 var hovered = lastForm.GetHoveredControl();
-                if (hovered != null) return hovered;
-            }
+                if (hovered != null) 
+                    return hovered;
 
+                //back control (note: double tries so that tooltip from multiple window layer can be displayed at once)
+                lastForm = Application.OpenForms.OfType<Form>().FirstOrDefault(x => !(x is ToolTipForm) && x.Visible);
+                if (lastForm != null) {
+                    hovered = lastForm.GetHoveredControl();
+                    if (hovered != null) return hovered;
+                }
+            }
             return null;
         }
 

--- a/ZeroKLobby/Utils.cs
+++ b/ZeroKLobby/Utils.cs
@@ -115,10 +115,9 @@ namespace ZeroKLobby
             if (!parentControl.DisplayRectangle.Contains(parentPoint)) return null;
             Control child;
             while (
-                (child =
-                 parentControl.GetChildAtPoint(parentPoint,
-                                               GetChildAtPointSkip.Disabled | GetChildAtPointSkip.Invisible | GetChildAtPointSkip.Transparent)) !=
-                null) {
+                (child = parentControl.GetChildAtPoint(parentPoint,
+                                               GetChildAtPointSkip.Disabled | GetChildAtPointSkip.Invisible | 
+                                               GetChildAtPointSkip.Transparent)) != null) {
                 parentControl = child;
                 parentPoint = parentControl.PointToClient(screenPoint);
             }


### PR DESCRIPTION
Turn out the ordering of the control matters. I do double retrieval, first & last. 

Last control turn out to be from forewindow, and first control turn out to be from back window

---

One tiny silliness that could happen is if foreground window become background. You see! (try with Springsettingform being behind MainWindow). The sequence of retrieval matters, but IMO not need so much perfection as long as tooltip never failed appearing.
