### PR TITLE
ZKL: quickfix for a crash reported by TheSponge

### DIFF
--- a/ZeroKLobby/MainWindow.cs
+++ b/ZeroKLobby/MainWindow.cs
@@ -135,17 +135,24 @@ namespace ZeroKLobby
 
         public Control GetHoveredControl() {
             Control hovered;
-            if (ActiveForm != null && ActiveForm.Visible && !(ActiveForm is ToolTipForm))
+            try
             {
-                hovered = ActiveForm.GetHoveredControl();
-                if (hovered != null)
-                    return hovered;
+                if (ActiveForm != null && ActiveForm.Visible && !(ActiveForm is ToolTipForm))
+                {
+                    hovered = ActiveForm.GetHoveredControl();
+                    if (hovered != null)
+                        return hovered;
+                }
+                foreach (var lastForm in Application.OpenForms.OfType<Form>().Where(x => !(x is ToolTipForm) && x.Visible))
+                {
+                    hovered = lastForm.GetHoveredControl();
+                    if (hovered != null)
+                        return hovered;
+                }
             }
-            foreach (var lastForm in Application.OpenForms.OfType<Form>().Where(x => !(x is ToolTipForm) && x.Visible))
+            catch (Exception e)
             {
-                hovered = lastForm.GetHoveredControl();
-                if (hovered != null) 
-                    return hovered;
+                Trace.TraceError("MainWindow.GetHoveredControl error:", e); //random crash with NULL error on line 140, is weird since already have NULL check (high probability in Linux when we changed focus)
             }
             return null;
         }


### PR DESCRIPTION
A quickfix to a crash that seem to happen when window loose focus. Crash happen in Linux but did saw in Windows once.

Crash is bad on Linux because it restart ZKL
