### PR TITLE
ZKL: fix detail button not working. 

### DIFF
--- a/ZeroKLobby/EngineConfigurator.cs
+++ b/ZeroKLobby/EngineConfigurator.cs
@@ -200,6 +200,7 @@ namespace ZeroKLobby
         public static string ReadResourceString(string uri) {
             try {
                 var obj = Configs.ResourceManager.GetObject(uri);
+                if (obj == null) return null;
                 if (obj is string) return obj as string;
                 return Encoding.UTF8.GetString((byte[])obj);
             } catch (Exception ex) {


### PR DESCRIPTION
Missing NULL check cause EngineConfigurator.cs to crash when it can't find non-existent cmdcolor2.txt
Fix https://github.com/ZeroK-RTS/Zero-K/issues/223
