### PR TITLE
ZKL: add option to disable tooltip for issue 328

### DIFF
--- a/ZeroKLobby/Config.cs
+++ b/ZeroKLobby/Config.cs
@@ -113,6 +113,25 @@ namespace ZeroKLobby
         [DisplayName("Disable Bubble On Private Message")]
         public bool DisablePmBubble { get; set; }
 
+        [Category("Tooltip")]
+        [DisplayName("Disable player tooltip")]
+        [Description("Disable ZKL tooltip that display player status.")]
+        public bool DisablePlayerTooltip { get; set; }
+
+        [Category("Tooltip")]
+        [DisplayName("Disable battle tooltip")]
+        [Description("Disable ZKL tooltip that display room information.")]
+        public bool DisableBattleTooltip { get; set; }
+
+        [Category("Tooltip")]
+        [DisplayName("Disable map tooltip")]
+        [Description("Disable ZKL tooltip that display map and minimap information.")]
+        public bool DisableMapTooltip { get; set; }
+
+        [Category("Tooltip")]
+        [DisplayName("Disable text tooltip")]
+        [Description("Disable ZKL tooltip that display tips on buttons and options.")]
+        public bool DisableTextTooltip { get; set; }
 
         [Category("Chat")]
         [DisplayName("Color: Emote")]
@@ -133,7 +152,7 @@ namespace ZeroKLobby
         [Category("Devving")]
         [DisplayName("Enable UnitSync Dialog Box")]
         [Description("Allow ZKL to process new mod/map information without connecting to server, "
-        + "and give user the choice to keep this information only in local cache rather than sharing it with server. This option is meant to be used with Skirmisher Tab. This option won't work on Linux")]
+        + "and give user the choice to keep this information only in local cache rather than sharing it with server. This option is meant to be used with Skirmisher Tab. This option is force disabled on Linux")]
         public bool EnableUnitSyncPrompt { get; set; }
 
         [XmlIgnore]

--- a/ZeroKLobby/Controls/MinimapFuncBox.cs
+++ b/ZeroKLobby/Controls/MinimapFuncBox.cs
@@ -1,14 +1,9 @@
-﻿using LobbyClient;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using ZeroKLobby;
-using ZeroKLobby.Lines;
 using ZkData;
-using ZkData.UnitSyncLib;
-using ZeroKLobby.MicroLobby.ExtrasTab;
 
 namespace ZeroKLobby.Controls
 {
@@ -17,6 +12,7 @@ namespace ZeroKLobby.Controls
         public MinimapFuncBox()
         {
             InitializeComponent();
+
             Program.ToolTip.SetText(btnGameOptions, "List available map/mod-options");
             Program.ToolTip.SetText(btnMapList, "List featured maps");
             Program.ToolTip.SetText(btnChangeTeam, "Create or move to new team");

--- a/ZeroKLobby/MicroLobby/SettingsTab.cs
+++ b/ZeroKLobby/MicroLobby/SettingsTab.cs
@@ -14,7 +14,7 @@ namespace ZeroKLobby.MicroLobby
 
 		public SettingsTab()
 		{
-			InitializeComponent(); //Fixme: tooltip for button don't appear on Linux. Diagnosis so far: button failed to be the Child of the elements or had "" as name.
+			InitializeComponent();
 
 			helpButton.MouseUp += helpButton_MouseUp;
 

--- a/ZeroKLobby/Program.cs
+++ b/ZeroKLobby/Program.cs
@@ -189,7 +189,7 @@ namespace ZeroKLobby
                 SpringScanner = new SpringScanner(SpringPaths);
                 SpringScanner.LocalResourceAdded += (s, e) => Trace.TraceInformation("New resource found: {0}", e.Item.InternalName);
                 SpringScanner.LocalResourceRemoved += (s, e) => Trace.TraceInformation("Resource removed: {0}", e.Item.InternalName);
-                if (Program.Conf.EnableUnitSyncPrompt)
+                if (Program.Conf.EnableUnitSyncPrompt && Environment.OSVersion.Platform != PlatformID.Unix)
                 {
                     SpringScanner.UploadUnitsyncData += MicroForms.UnitSyncUploadPrompt.SpringScanner_UploadUnitsyncData;
                     SpringScanner.RetryResourceCheck += MicroForms.UnitSyncRetryPrompt.SpringScanner_RetryGetResourceInfo;

--- a/ZeroKLobby/ToolTips/PlayerTooltipRenderer.cs
+++ b/ZeroKLobby/ToolTips/PlayerTooltipRenderer.cs
@@ -162,6 +162,7 @@ namespace ZeroKLobby
                 if (user.IsInGame) h += 16; // ingame icon
                 h += 16; // skill text
             }
+            if (user.SteamID!=null) h += 16; //steam icon
             if (Program.SpringieServer.GetTop10Rank(user.Name) > 0) h += 16; // top 10
             if (user.IsInBattleRoom) h += 76; // battle icon
 

--- a/ZeroKLobby/ToolTips/ToolTipHandler.cs
+++ b/ZeroKLobby/ToolTips/ToolTipHandler.cs
@@ -217,7 +217,6 @@ namespace ZeroKLobby
 
                 if (!attachedDisposer.Contains(control))
                 {
-                	System.Diagnostics.Trace.TraceInformation("attachedDisposer");
                     (control as Control).Disposed += (sender, e) => { Clear(sender); };
                     attachedDisposer.Add(control);
                 }

--- a/ZeroKLobby/ToolTips/ToolTipHandler.cs
+++ b/ZeroKLobby/ToolTips/ToolTipHandler.cs
@@ -35,6 +35,7 @@ namespace ZeroKLobby
 
         private ToolTipForm tooltip;
         private readonly Dictionary<object, string> tooltips = new Dictionary<object, string>();
+        private readonly List<object> attachedDisposer = new List<object>();
 
         private bool visible = true;
         public bool Visible {
@@ -202,10 +203,26 @@ namespace ZeroKLobby
 
         private bool requestRefresh = false;
         private void UpdateTooltip(object control, string s) {
-            (control as Control).Disposed += (sender, e) => 
+            if (!String.IsNullOrEmpty(s))
             {
-                Clear(sender); 
-            };
+                if (
+                (Program.Conf.DisablePlayerTooltip && s.StartsWith ("#user#"))
+                || (Program.Conf.DisableBattleTooltip && s.StartsWith ("#battle#")) 
+                || (Program.Conf.DisableMapTooltip && s.StartsWith ("#map#")) 
+                || (Program.Conf.DisableTextTooltip && (s[0]!='#' || !(s.StartsWith ("#user#") || s.StartsWith ("#battle#") || s.StartsWith ("#map#"))))
+                )
+                {
+                    return;
+                }
+
+                if (!attachedDisposer.Contains(control))
+                {
+                	System.Diagnostics.Trace.TraceInformation("attachedDisposer");
+                    (control as Control).Disposed += (sender, e) => { Clear(sender); };
+                    attachedDisposer.Add(control);
+                }
+            }
+
             tooltips[control] = s;
             requestRefresh = true; //RefreshToolTip(true);
         }

--- a/ZeroKLobby/Utils.cs
+++ b/ZeroKLobby/Utils.cs
@@ -358,7 +358,7 @@ namespace ZeroKLobby
         }
 
         /// <summary>
-        /// Reverse DPI scaling
+        /// Calculate reverse DPI scaling
         /// </summary>
         public static int ReverseScaleValueX(double designHeight) {
             var output = designHeight*scaleDownRatioX;
@@ -366,7 +366,7 @@ namespace ZeroKLobby
         }
 
         /// <summary>
-        /// Reverse DPI scaling
+        /// Calculate reverse DPI scaling
         /// </summary>
         public static int ReverseScaleValueY(double designHeight) {
             var output = designHeight*scaleDownRatioY;
@@ -374,7 +374,7 @@ namespace ZeroKLobby
         }
 
         /// <summary>
-        /// Apply DPI scaling
+        /// Calculate DPI scaling
         /// </summary>
         public static int ScaleValueX(double designWidth) {
             var output = designWidth*scaleUpRatioX;
@@ -382,7 +382,7 @@ namespace ZeroKLobby
         }
 
         /// <summary>
-        /// Apply DPI scaling
+        /// Calculate DPI scaling
         /// </summary>
         public static int ScaleValueY(double designHeight) {
             var output = designHeight*scaleUpRatioY;


### PR DESCRIPTION
1) simply added option to disable tooltip for people who might not need tooltip. a workaround for #328 (fix #328 )

2) hard disabled Unitsync question box for Linux (because it cause hang there)

3) fix steam name tag cause their battleroom tooltip to cut off