### PR TITLE
Springie rights display on profile

### DIFF
--- a/Zero-K.info/Views/Shared/UserDetail.cshtml
+++ b/Zero-K.info/Views/Shared/UserDetail.cshtml
@@ -10,7 +10,7 @@
 }
 
 @{
-    int normalLevel = Model.IsZeroKAdmin ? 4 : (Model.Level >= GlobalConst.LevelForElevatedSpringieRights ? 2 : 1);
+    int normalLevel = Model.Level >= GlobalConst.LevelForElevatedSpringieRights ? 2 : 1;
 }
 
 @{
@@ -111,7 +111,7 @@
                     <b> @Model.Name </b> is a <b>Zero-K Administrator</b>
                 </div>
             }
-            @if ( Model.SpringieLevel != normalLevel ) {
+            @if ( Model.SpringieLevel != normalLevel && !Model.IsZeroKAdmin ) {
                 <b>Springie rights level:</b> @Model.SpringieLevel
                 <br />
             }


### PR DESCRIPTION
Non-standard Springie rights are not displayed for people who can change that themselves (because they can have any rights they want practically, and there is no standard rights value for them)