### PR TITLE
fix tooltips, update image urls

### DIFF
--- a/Zero-K.info/App_Start/BundleConfig.cs
+++ b/Zero-K.info/App_Start/BundleConfig.cs
@@ -1,0 +1,33 @@
+﻿using System.Web.Optimization;
+
+public class BundleConfig
+{
+    public static void RegisterBundles(BundleCollection bundles)
+    {
+        bundles.Add(new ScriptBundle("~/bundles/main").Include(
+            "~/Scripts/MicrosoftAjax.js",
+            "~/Scripts/MicrosoftMvcAjax.js",
+            "~/Scripts/jquery-1.5.2.min.js",
+            "~/Scripts/jquery-ui-1.8.14.custom.min.js",
+            "~/Scripts/jquery.ui.stars.js",
+            "~/Scripts/jquery.tablesorter.min.js",
+            "~/Scripts/jquery.qtip.pack.js",
+            "~/Scripts/site_main.js",
+            "~/Scripts/base.js",
+            "~/Scripts/browser-css.js",
+            "~/Scripts/nicetitle.js",
+            "~/Scripts/raphael-min.js"));
+
+        bundles.Add(new StyleBundle("~/bundles/maincss").Include(
+            "~/Styles/fonts.css",
+            "~/Styles/base.css",
+            "~/Styles/menu.css",
+            "~/Styles/stars.css",
+            "~/Styles/levelrank.css",
+            "~/Styles/jquery.ui.stars.css",
+            "~/Styles/style.css",
+            "~/Styles/jquery.qtip.min.css",
+            "~/Styles/dark-hive/jquery-ui-1.8.14.custom.css",
+            "~/Styles/nicetitle.css"));
+    }
+}

--- a/Zero-K.info/Global.asax.cs
+++ b/Zero-K.info/Global.asax.cs
@@ -12,6 +12,7 @@ using NightWatch;
 using ServiceStack.Text;
 using ZeroKWeb.Controllers;
 using ZkData;
+using System.Web.Optimization;
 
 namespace ZeroKWeb
 {
@@ -80,6 +81,8 @@ namespace ZeroKWeb
 
         protected void Application_Start()
         {
+            BundleConfig.RegisterBundles(BundleTable.Bundles);
+
             var nw = new Nightwatch(Server.MapPath("/"));
             Application["Nightwatch"] = nw;
             if (GlobalConst.PlanetWarsMode == PlanetWarsModes.Running) Application["PwMatchMaker"] = new PlanetWarsMatchMaker(nw.Tas);            

--- a/Zero-K.info/Styles/base.css
+++ b/Zero-K.info/Styles/base.css
@@ -87,7 +87,7 @@ ul {list-style-type: circle;}
 
 .border
 {
-	background: #000 url("../img/border-1.png") repeat-x scroll 50% 0;
+	background: #000 url("/img/border-1.png") repeat-x scroll 50% 0;
 	margin: 10px;
 	padding: 5px;
     /**/border: 1px solid #2a8eaf;/**/
@@ -99,9 +99,9 @@ ul {list-style-type: circle;}
     -webkit-box-shadow: 0 0 3px 3px #000;
     
     /*
-    -moz-border-image: url("../img/zk_border.png") 10% 10% 10% 10% / 10px 10px 10px 10px ;
-    -webkit-border-image: url("../img/zk_border.png") 10% 10% 10% 10% / 10px 10px 10px 10px ;
-    -border-image: url("../img/zk_border.png") 10% 10% 10% 10% / 10px 10px 10px 10px ;
+    -moz-border-image: url("/img/zk_border.png") 10% 10% 10% 10% / 10px 10px 10px 10px ;
+    -webkit-border-image: url("/img/zk_border.png") 10% 10% 10% 10% / 10px 10px 10px 10px ;
+    -border-image: url("/img/zk_border.png") 10% 10% 10% 10% / 10px 10px 10px 10px ;
     -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=88)";
     /**/
 }

--- a/Zero-K.info/Styles/menu.css
+++ b/Zero-K.info/Styles/menu.css
@@ -40,7 +40,7 @@ ul.menu li:hover > ul /*dropdown part*/
 {
 	display:block;
 	position:absolute;
-	background: #000 url("../img/border-1.png") repeat-x scroll 50% 0;
+	background: #000 url("/img/border-1.png") repeat-x scroll 50% 0;
 	padding: 5px;
     margin: 0px;
 	border: 1px solid #2a8eaf;

--- a/Zero-K.info/Styles/nicetitle.css
+++ b/Zero-K.info/Styles/nicetitle.css
@@ -1,6 +1,6 @@
  .nicetitle, .ui-tooltip, .qtip
 {
-    background: #000 url("../img/border-1.png") repeat-x;
+    background: #000 url("/img/border-1.png") repeat-x;
     position: absolute;
     padding: 8px;
     top: 0px;

--- a/Zero-K.info/Styles/stars.css
+++ b/Zero-K.info/Styles/stars.css
@@ -1,30 +1,30 @@
  .GreenStarSmall { 
   height: 14px;
   display: inline-block;
-  background: url(../img/stars/star_green_small.png) 0 0;
+  background: url(/img/stars/star_green_small.png) 0 0;
  } 
  
  .RedStarSmall { 
   height: 14px;
   display: inline-block;
-  background: url(../img/stars/star_red_small.png) 0 0;
+  background: url(/img/stars/star_red_small.png) 0 0;
  } 
 
  .RedSkull { 
   height: 14px;
   display: inline-block;
-  background: url(../img/stars/skulls.png) 0 -56px;
+  background: url(/img/stars/skulls.png) 0 -56px;
  } 
 
  .WhiteSkull { 
   height: 14px;
   display: inline-block;
-  background: url(../img/stars/skulls.png) 0 -28px;
+  background: url(/img/stars/skulls.png) 0 -28px;
  } 
  
  .WhiteStarSmall { 
   height: 14px;
   display: inline-block;
-  background: url(../img/stars/star_white_small.png) 0 0;
+  background: url(/img/stars/star_white_small.png) 0 0;
  } 
  

--- a/Zero-K.info/Styles/style.css
+++ b/Zero-K.info/Styles/style.css
@@ -1,12 +1,3 @@
-@import url("fonts.css");
-@import url("base.css");
-@import url("menu.css");
-@import url("nicetitle.css");
-@import url("stars.css");
-@import url("levelrank.css");
-@import url("jquery.ui.stars.css");
-@import url(http://www.google.com/cse/api/branding.css);
-
 .js_tabs {}
 
 html
@@ -36,7 +27,7 @@ body
 
 #fadetoblack
 {
-	background: url("../img/fade.png") repeat-y 50% 0;
+	background: url("/img/fade.png") repeat-y 50% 0;
     position: fixed;
     top: 0px;
     left: 0px;
@@ -85,13 +76,13 @@ div#footer
 
 ul.forumtab
 {
-    list-style-image: url("../../Img/bullet.png");
+    list-style-image: url("/img/bullet.png");
     padding-left: 15px;
 }
 
 hr.pretty
 {
-	background: url("../../img/hr_img1.png");
+	background: url("/img/hr_img1.png");
 	width: 80%;
 	height: 1px;
 }
@@ -133,18 +124,11 @@ div#ajaxScrollProgress
 	padding: 5px;
     border-style: solid;
 	border-radius: 15px;
-	border-image:url("dark-hive/images/tech_button.png") 24 fill / 15px stretch;
+	border-image:url("/styles/dark-hive/images/tech_button.png") 24 fill / 15px stretch;
 	background: #333;
     box-shadow: 0 0 3px 3px #000;
 	-moz-box-shadow: 0 0 3px 3px #000;
     -webkit-box-shadow: 0 0 3px 3px #000;
-    
-    /* old border image 
-    -moz-border-image: url("../img/zk_border.png") 10% 10% 10% 10% / 10px 10px 10px 10px ;
-    -webkit-border-image: url("../img/zk_border.png") 10% 10% 10% 10% / 10px 10px 10px 10px ;
-    -border-image: url("../img/zk_border.png") 10% 10% 10% 10% / 10px 10px 10px 10px ;
-    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=88)";
-    /**/
 }
 
 .ie .border
@@ -158,20 +142,20 @@ div#ajaxScrollProgress
 {
     height: 45px;
     width: 45px;
-    background-image: url("../img/downloadBlue45.png");
+    background-image: url("/img/downloadBlue45.png");
     display: inline-block;
     vertical-align:middle;
 }
 
 .buttonSpan:hover
 {
-    background-image: url("../img/downloadBlue45_2.png");
+    background-image: url("/img/downloadBlue45_2.png");
 }
 
 .textbutton
 {
 	display: inline-block;
-	background: #000 url("../Img/download.png") no-repeat center;
+	background: #000 url("/img/download.png") no-repeat center;
 	color: #38bfec;
 	border-radius: 5px;
 	border: 1px solid #2a8eaf;
@@ -196,7 +180,7 @@ div#ajaxScrollProgress
 {
 	position: relative;
 	display: block;
-	background: #000 url("../Img/download.png") no-repeat center;
+	background: #000 url("/img/download.png") no-repeat center;
 	color: #38bfec;
 	border-radius: 5px;
 	border: 1px solid #2a8eaf;
@@ -300,12 +284,12 @@ span.button_2text
 
 .toggleFalse
 {
-	background: url("../img/bg_black_translucent.png");
+	background: url("/img/bg_black_translucent.png");
 }
 
 .toggleTrue
 {
-	background: url("../img/bg_111_translucent.png");
+	background: url("/img/bg_111_translucent.png");
 }
 
 /* Single Player missions
@@ -529,7 +513,7 @@ span.button_2text
   border-style: solid;
   border-radius:10px;
   border-color:transparent;
-  border-image: url("dark-hive/images/tech_button.png") 24 24 24 24 fill / 15px 15px 15px 15px;
+  border-image: url("/styles/dark-hive/images/tech_button.png") 24 24 24 24 fill / 15px 15px 15px 15px;
   padding:10px;
 }
 
@@ -537,7 +521,7 @@ span.button_2text
 {
   background-color:#204040;
   border-style: solid;
-  border-image: url("dark-hive/images/tech_button.png") 24 24 24 24 fill / 15px 15px 15px 15px;
+  border-image: url("/styles/dark-hive/images/tech_button.png") 24 24 24 24 fill / 15px 15px 15px 15px;
   border-radius: 10px;
   border-color:transparent;
   max-width: 700px;

--- a/Zero-K.info/Views/Shared/_SiteLayout.cshtml
+++ b/Zero-K.info/Views/Shared/_SiteLayout.cshtml
@@ -38,22 +38,8 @@
             })();
         </script>
         <link rel="icon" href='@Href("~/img/favicon.png")'/>
-        <link rel="Stylesheet" href='@Href("~/Styles/style.css")' type="text/css" />
-        <link rel="Stylesheet" href='@Href("~/Styles/jquery.qtip.min.css")' type="text/css" />
-        <link rel="Stylesheet" href='@Href("~/Styles/dark-hive/jquery-ui-1.8.14.custom.css")' type="text/css" />
-        <link rel="Stylesheet" href='@Href("~/Styles/nicetitle.css")' type="text/css" />
-        <script type="text/javascript" src='@Href("~/Scripts/MicrosoftAjax.js")' > </script>
-        <script type="text/javascript" src='@Href("~/Scripts/MicrosoftMvcAjax.js")' > </script>
-        <script type="text/javascript" src='@Href("~/Scripts/jquery-1.5.2.min.js")' > </script>
-        <script type="text/javascript" src='@Href("~/Scripts/jquery-ui-1.8.14.custom.min.js")' > </script>
-        <script type="text/javascript" src='@Href("~/Scripts/jquery.ui.stars.js")' > </script>
-        <script type="text/javascript" src='@Href("~/Scripts/jquery.tablesorter.min.js")' > </script>
-        <script type="text/javascript" src='@Href("~/Scripts/jquery.qtip.pack.js")' > </script>
-        <script type="text/javascript" src='@Href("~/Scripts/site_main.js")' > </script> 
-        <script type="text/javascript" src='@Href("~/Scripts/base.js")' > </script>
-        <script type="text/javascript" src='@Href("~/Scripts/browser-css.js")' > </script>
-        <script type="text/javascript" src='@Href("~/Scripts/nicetitle.js")' > </script>
-        <script type="text/javascript" src='@Href("~/Scripts/raphael-min.js")' > </script>
+        @System.Web.Optimization.Styles.Render("~/bundles/maincss")
+        @System.Web.Optimization.Scripts.Render("~/bundles/main")
         
         @RenderSection("head", false)
         @if (!Global.IsLobbyAccess && ViewBag.Minimal != true && Request["minimalDesign"] != "1" && !Global.IsWebLobbyAccess) {

--- a/Zero-K.info/Web.config
+++ b/Zero-K.info/Web.config
@@ -115,6 +115,14 @@
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="1.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>

--- a/Zero-K.info/asp.net.csproj
+++ b/Zero-K.info/asp.net.csproj
@@ -30,8 +30,12 @@
     <RestorePackages>true</RestorePackages>
     <MvcProjectUpgradeChecked>true</MvcProjectUpgradeChecked>
     <WcfConfigValidationEnabled>True</WcfConfigValidationEnabled>
+    <WebGreaseLibPath>..\packages\WebGrease.1.5.2\lib</WebGreaseLibPath>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Antlr3.Runtime">
+      <HintPath>..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
+    </Reference>
     <Reference Include="CookComputing.XmlRpcV2, Version=2.5.0.0, Culture=neutral, PublicKeyToken=a7d6e17aa302004d, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Libs\CookComputing.XmlRpcV2.dll</HintPath>
@@ -80,6 +84,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.2\lib\net45\System.Web.Mvc.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web.Optimization">
+      <HintPath>..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.2\lib\net45\System.Web.Razor.dll</HintPath>
@@ -96,6 +103,12 @@
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
+    <Reference Include="WebActivatorEx">
+      <HintPath>..\packages\WebActivatorEx.2.0.6\lib\net40\WebActivatorEx.dll</HintPath>
+    </Reference>
+    <Reference Include="WebGrease">
+      <HintPath>..\packages\WebGrease.1.5.2\lib\WebGrease.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppCode\Auth.cs" />
@@ -105,6 +118,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>ModStatsDb.dbml</DependentUpon>
     </Compile>
+    <Compile Include="App_Start\BundleConfig.cs" />
     <Compile Include="ContentService.svc.cs">
       <DependentUpon>ContentService.svc</DependentUpon>
     </Compile>

--- a/Zero-K.info/packages.config
+++ b/Zero-K.info/packages.config
@@ -1,14 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.2" targetFramework="net45" />
   <package id="MarkdownDeep.NET" version="1.4" targetFramework="net40" />
   <package id="MarkdownHelper" version="1.3" targetFramework="net40" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.2" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.2" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
   <package id="Microsoft.Linq.Translations" version="1.0.1" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net45" />
   <package id="ServiceStack.Text" version="3.9.48" targetFramework="net40" />
+  <package id="WebGrease" version="1.5.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
fixed 08f3957a1ce6f6de54b9a33faa7f57c3438f225b 
- tooltip styles now work properly (nicetitle.css was duplicated)
- updated all(?) images in css to absolute paths.

Only css missing from there is the ref to branding.css, since it doesn't appear to be used anywhere. If needed it can be readded to siteLayout outside of the bundle