### PR TITLE
Use github as source for award images

### DIFF
--- a/Zero-K.info/Views/Battles/Detail.cshtml
+++ b/Zero-K.info/Views/Battles/Detail.cshtml
@@ -117,7 +117,7 @@
                     		}
                     @foreach (var award in Model.AccountBattleAwards.Where(x => x.AccountID == u.AccountID))
                     {
-                        <img src="http://zero-k.googlecode.com/svn/trunk/mods/zk/LuaRules/Images/awards/trophy_@(award.AwardKey).png" height="30" title="@award.AwardDescription"/>
+                        <img src="https://raw.githubusercontent.com/ZeroK-RTS/Zero-K/master/LuaRules/Images/awards/trophy_@(award.AwardKey).png" height="30" title="@award.AwardDescription"/>
                     }
                 </span>
                 <br />

--- a/Zero-K.info/Views/Home/UserTooltip.cshtml
+++ b/Zero-K.info/Views/Home/UserTooltip.cshtml
@@ -36,7 +36,7 @@
     @foreach (var award in Model.AccountBattleAwards.GroupBy(x => x.AwardKey).OrderByDescending(x => x.Count()))
     {
         <div class="fleft border" style="margin: 3px;">
-            <img src="http://zero-k.googlecode.com/svn/trunk/mods/zk/LuaRules/Images/awards/trophy_@(award.Key).png" height="30" alt="@award.Key" title="@award.First().AwardDescription.Split(',').First()"/>
+            <img src="https://raw.githubusercontent.com/ZeroK-RTS/Zero-K/master/LuaRules/Images/awards/trophy_@(award.Key).png" height="30" alt="@award.Key" title="@award.First().AwardDescription.Split(',').First()"/>
             <br />
             <center>@award.Count()</center>
         </div>

--- a/Zero-K.info/Views/Ladders/ladders.cshtml
+++ b/Zero-K.info/Views/Ladders/ladders.cshtml
@@ -53,7 +53,7 @@
     <div style="height: 80px;">
         <div style="position: absolute; width: 60px;" >
             <span title="@awardItem.AwardTitle">
-                <img src="http://zero-k.googlecode.com/svn/trunk/mods/zk/LuaRules/Images/awards/trophy_@(awardItem.AwardType).png" height="30" alt="@awardItem.AwardType" />
+                <img src="https://raw.githubusercontent.com/ZeroK-RTS/Zero-K/master/LuaRules/Images/awards/trophy_@(awardItem.AwardType).png" height="30" alt="@awardItem.AwardType" />
             </span>
         </div>
         

--- a/Zero-K.info/Views/Shared/UserDetail.cshtml
+++ b/Zero-K.info/Views/Shared/UserDetail.cshtml
@@ -187,7 +187,7 @@
             <h3>Trophies:</h3>
             @foreach (var award in Model.AccountBattleAwards.GroupBy(x => x.AwardKey).OrderByDescending(x => x.Count())) {
                 <div class="fleft border" style="margin: 3px;">
-                    <img src="http://zero-k.googlecode.com/svn/trunk/mods/zk/LuaRules/Images/awards/trophy_@(award.Key).png" height="30" alt="@award.Key" title="@award.First().AwardDescription.Split(',').First()"/>
+                    <img src="https://raw.githubusercontent.com/ZeroK-RTS/Zero-K/master/LuaRules/Images/awards/trophy_@(award.Key).png" height="30" alt="@award.Key" title="@award.First().AwardDescription.Split(',').First()"/>
                     <br />
                     <center>@award.Count()</center>
                 </div>


### PR DESCRIPTION
I'm not actually sure this will work as-is but it seems to when i hack the image src attribute in firebug and we have a test environment yay!

This is somewhat of a requirement for tourney award images but i guess i could svn commit them as well.