### PR TITLE
ZKL: small fix for Skirmisher and playerlist

### DIFF
--- a/ZeroKLobby/MicroLobby/ExtrasTab/SkirmishControl.cs
+++ b/ZeroKLobby/MicroLobby/ExtrasTab/SkirmishControl.cs
@@ -139,8 +139,18 @@ namespace ZeroKLobby.MicroLobby.ExtrasTab
             Setup_ComboBox();
             if (!string.IsNullOrEmpty(Program.Conf.SkirmisherEngine))
                 engine_comboBox.SelectedItem = Program.Conf.SkirmisherEngine;
+            else 
+                engine_comboBox.SelectedItem = GlobalConst.DefaultEngineOverride ?? Program.TasClient.ServerSpringVersion;
+            
             if (!string.IsNullOrEmpty(Program.Conf.SkirmisherGame))
                 game_comboBox.SelectedItem = Program.Conf.SkirmisherGame;
+            else
+            {
+                var gameVer = Program.Downloader.PackageDownloader.GetByTag(KnownGames.GetDefaultGame().RapidTag);
+                if (gameVer!=null)
+                    game_comboBox.SelectedItem = gameVer.InternalName;
+            }
+            
             if (!string.IsNullOrEmpty(Program.Conf.SkirmisherMap))
                 map_comboBox.SelectedItem = Program.Conf.SkirmisherMap;
             
@@ -364,10 +374,10 @@ namespace ZeroKLobby.MicroLobby.ExtrasTab
             {
                 if (minimap == null) return;
                 var boxColors = new[]
-		                        {
-		                            Color.Green, Color.Red, Color.Blue, Color.Cyan, Color.Yellow, Color.Magenta, Color.Gray, Color.Lime, Color.Maroon,
-		                            Color.Navy, Color.Olive, Color.Purple, Color.Silver, Color.Teal, Color.White,
-		                        };
+                                {
+                                    Color.Green, Color.Red, Color.Blue, Color.Cyan, Color.Yellow, Color.Magenta, Color.Gray, Color.Lime, Color.Maroon,
+                                    Color.Navy, Color.Olive, Color.Purple, Color.Silver, Color.Teal, Color.White,
+                                };
                 var xScale = (double)minimapBox.Width / minimapSize.Width;
                 // todo remove minimapSize and use minimap image directly when plasmaserver stuff fixed
                 var yScale = (double)minimapBox.Height / minimapSize.Height;
@@ -578,7 +588,7 @@ namespace ZeroKLobby.MicroLobby.ExtrasTab
         }
 
         private bool isClick = false;
-        private void Event_PlayerBox_MouseDown(object sender, MouseEventArgs mea)	{	isClick=true;	}
+        private void Event_PlayerBox_MouseDown(object sender, MouseEventArgs mea)    {    isClick=true;    }
 
         //using MouseUp because it allow the PlayerBox's "HoverItem" to return correct value when we click on it rapidly
         private void Event_PlayerBox_MouseUp(object sender, MouseEventArgs mea) //from BattleChatControl
@@ -994,7 +1004,12 @@ namespace ZeroKLobby.MicroLobby.ExtrasTab
                     infoLabel.Text = "";
 
                 Set_InfoLabel();
-                Program.Conf.SkirmisherGame = gameName;
+                
+                var defGameVer = Program.Downloader.PackageDownloader.GetByTag(KnownGames.GetDefaultGame().RapidTag);
+                if (defGameVer!=null && gameName == defGameVer.InternalName)
+                    Program.Conf.SkirmisherGame = null; //tell Skirmisher to use default in next startup
+                else
+                    Program.Conf.SkirmisherGame = gameName;
 
             }
             else if ((sender as Control).Name == "engine_comboBox" && engine_comboBox.SelectedItem != null)
@@ -1015,7 +1030,11 @@ namespace ZeroKLobby.MicroLobby.ExtrasTab
                     infoLabel.Text = "";
 
                 Set_InfoLabel();
-                Program.Conf.SkirmisherEngine = (string)engine_comboBox.SelectedItem;
+                
+                if ((string)engine_comboBox.SelectedItem == (GlobalConst.DefaultEngineOverride ?? Program.TasClient.ServerSpringVersion))
+                    Program.Conf.SkirmisherEngine = null; //tell Skirmihser to use default in next run
+                else
+                    Program.Conf.SkirmisherEngine = (string)engine_comboBox.SelectedItem;
 
                 if (Program.SpringPaths.HasEngineVersion(springVersion))
                     springAi = SkirmishControlTool.GetSpringAIs(engineFolder);

--- a/ZeroKLobby/MicroLobby/ExtrasTab/SkirmishControl.cs
+++ b/ZeroKLobby/MicroLobby/ExtrasTab/SkirmishControl.cs
@@ -71,6 +71,7 @@ namespace ZeroKLobby.MicroLobby.ExtrasTab
             minimapBox.MouseUp += Event_MinimapBox_MouseUp;
             skirmPlayerBox.IsBattle = true;
             skirmPlayerBox.MouseDown += Event_PlayerBox_MouseDown;
+            skirmPlayerBox.MouseUp += Event_PlayerBox_MouseUp;
 
             Program.SpringScanner.LocalResourceAdded += Event_SpringScanner_LocalResourceAdded;
             Program.SpringScanner.LocalResourceRemoved += Event_SpringScanner_LocalResourceAdded;
@@ -234,7 +235,7 @@ namespace ZeroKLobby.MicroLobby.ExtrasTab
                     string engineFolder = ZkData.Utils.MakePath(Program.SpringPaths.WritableDirectory, "engine");
                     engineList = System.IO.Directory.EnumerateDirectories(engineFolder, "*").ToList<string>();
                     for (int i = 0; i < engineList.Count; i++)
-                        engineList[i] = SkirmishControlTool.GetFolderName(engineList[i]);
+                        engineList[i] = SkirmishControlTool.GetFolderOrFileName(engineList[i]);
 
                     engineList = SkirmishControlTool.SortListByVersionName(engineList);
 
@@ -446,7 +447,7 @@ namespace ZeroKLobby.MicroLobby.ExtrasTab
 
             var newList = new List<PlayerListItem>();
             newList.Add(myItem);
-            List<PlayerListItem> playerListItems = new List<PlayerListItem>();
+            var playerListItems = new List<PlayerListItem>();
 
             if (!myItem.UserBattleStatus.IsSpectator || Bots.Count > 0) playerListItems.Add(myItem);
             var existingTeams = playerListItems.GroupBy(i => i.UserBattleStatus.AllyNumber).Select(team => team.Key).ToList();
@@ -576,10 +577,17 @@ namespace ZeroKLobby.MicroLobby.ExtrasTab
             Refresh_PlayerBox();
         }
 
-        private void Event_PlayerBox_MouseDown(object sender, MouseEventArgs mea) //from BattleChatControl
-        {
-            if (currentMod != null && currentMod.IsMission) return; //disable shorcuts for mission mod
+        private bool isClick = false;
+        private void Event_PlayerBox_MouseDown(object sender, MouseEventArgs mea)	{	isClick=true;	}
 
+        //using MouseUp because it allow the PlayerBox's "HoverItem" to return correct value when we click on it rapidly
+        private void Event_PlayerBox_MouseUp(object sender, MouseEventArgs mea) //from BattleChatControl
+        {
+            if (!isClick) return;
+            isClick = false;
+
+            if (currentMod != null && currentMod.IsMission) return; //disable shorcuts for mission mod
+            //change ally
             if (mea.Button == MouseButtons.Left)
             {
                 if (skirmPlayerBox.HoverItem != null)
@@ -596,12 +604,14 @@ namespace ZeroKLobby.MicroLobby.ExtrasTab
                         Set_MyBattleStatus(skirmPlayerBox.HoverItem.AllyTeam.Value, Get_FreeTeamID(myItem.UserName), false);
                 }
             }
-
+            //context menu
             if (mea.Button == MouseButtons.Right || !Program.Conf.LeftClickSelectsPlayer)
             {
-                if (skirmPlayerBox.HoverItem == null && mea.Button == MouseButtons.Right)
-                { //right click on empty space
-                    var cm = Get_PlayerContextMenu(myItem.User);
+                if (skirmPlayerBox.HoverItem != null && skirmPlayerBox.HoverItem.BotBattleStatus != null) //on bot name
+                {
+                    skirmPlayerBox.SelectedItem = skirmPlayerBox.HoverItem;
+
+                    var cm = Get_BotContextMenu(skirmPlayerBox.HoverItem.BotBattleStatus.Name);
                     Program.ToolTip.Visible = false;
                     try
                     {
@@ -615,26 +625,23 @@ namespace ZeroKLobby.MicroLobby.ExtrasTab
                     {
                         Program.ToolTip.Visible = true;
                     }
-                }
-                if (skirmPlayerBox.HoverItem != null)
+                }else //on name or empty space
                 {
-                    if (skirmPlayerBox.HoverItem.BotBattleStatus != null)
+                    skirmPlayerBox.SelectedItem = skirmPlayerBox.HoverItem;
+
+                    var cm = Get_PlayerContextMenu(myItem.User);
+                    Program.ToolTip.Visible = false;
+                    try
                     {
-                        skirmPlayerBox.SelectedItem = skirmPlayerBox.HoverItem;
-                        var cm = Get_BotContextMenu(skirmPlayerBox.HoverItem.BotBattleStatus.Name);
-                        Program.ToolTip.Visible = false;
-                        try
-                        {
-                            cm.Show(skirmPlayerBox, mea.Location);
-                        }
-                        catch (Exception ex)
-                        {
-                            Trace.TraceError("Error displaying tooltip: {0}", ex);
-                        }
-                        finally
-                        {
-                            Program.ToolTip.Visible = true;
-                        }
+                        cm.Show(skirmPlayerBox, mea.Location);
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace.TraceError("Error displaying tooltip: {0}", ex);
+                    }
+                    finally
+                    {
+                        Program.ToolTip.Visible = true;
                     }
                 }
             }

--- a/ZeroKLobby/MicroLobby/ExtrasTab/TableReader.cs
+++ b/ZeroKLobby/MicroLobby/ExtrasTab/TableReader.cs
@@ -1,0 +1,425 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ZeroKLobby.MicroLobby.ExtrasTab
+{
+	/// <summary>
+	/// Contain characters used by TableReader to parse table (default character set is for LUA table).
+	/// </summary>
+	public class TableReaderConfig
+	{
+		public String prefix="id_";
+		public String stringGlue = "...";
+		public char[] stringChars = new char[2]{'\'','"'};
+        public String blockStringOpen = "[[";
+        public String blockStringClose = "]]";
+        public String blockCommentOpen = "--[[";
+        public String blockCommentClose = "--]]";
+        public String commentString = "--";
+        public char tableOpen = '{';
+        public char tableClose = '}';
+        public char contentSeparator = ',';
+        public char[] newLineChar = {'\n','\r'};
+        public char whitespaceA = ' ';
+        public char whitespaceB = '\t';
+        public char escapeCharSign = '\\';
+        public char equalSign = '=';
+        
+        public TableReaderConfig()
+        {
+        }
+	}
+	
+	/// <summary>
+	/// Tool for parsing Spring related table.
+	/// </summary>
+	public static class TableReader
+	{
+        /// <summary>
+        /// Tbis function convert the content of a table inside an input text into a Dictionary(String,Object) object.
+		/// The parsing start from the first bracket '{' and end at the closing bracket '}'		
+		/// The search for bracket pairs "{}" start from argument "startIndex".
+		/// The function will output the index of closing bracket '}' as variable "offset" when it finishes.
+		/// The value in Dictionary(String,Object) will be another Dictionary(String,Object) when its a nexted table, or String when its normal value.
+		/// Note: This reader don't parse function and return value, and dont pre-calculate any math statement embedded in LUA table (will fail).
+		/// Example usage is in SkirmishControlTool.cs. Any improvement & simplification of this function is welcomed!
+		/// Currently able to extract content of Spring related LUA config files (including able to handle commented line) & Spring Startscript (use ';' as content saperator)
+		/// </summary>
+        public static Dictionary<String,Object> ParseTable(TableReaderConfig config, int startIndex, String text, String filePath, out int offset)
+        {
+            var contentList =new Dictionary<String,Object>();
+            String prefix= config.prefix;
+            
+            String stringGlue = config.stringGlue;
+            
+            int stringCharType = 0;
+            char[] stringChars = config.stringChars;
+            bool blockStringChar = false;
+            
+            int blockStringCount = 0;
+            String blockStringOpen = config.blockStringOpen;
+            String blockStringClose = config.blockStringClose;
+            bool blockStringString = false;
+            
+            int blockCommentCount = 0;
+            String blockCommentOpen = config.blockCommentOpen;
+            String blockCommentClose = config.blockCommentClose;
+            bool blockComment = false;
+            
+            int commentCharCount = 0;
+            String commentString = config.commentString;
+            bool lineComment = false;
+            
+            bool inTable = false;
+            char tableOpen = config.tableOpen;
+            char tableClose = config.tableClose;
+            
+            char contentSeparator = config.contentSeparator;
+            int contentIndex = 0;
+            
+            char[] newLineChar = config.newLineChar;
+            char whitespaceA = config.whitespaceA;
+            char whitespaceB = config.whitespaceB;
+            
+            String capturedValue1 = "";
+            String capturedValue2 = "";
+            Object capturedObject1 = null;
+            char escapeCharSign = config.escapeCharSign;
+            bool isEscapeCharNow = false;
+            bool detectedUnspacedChar = false;
+            
+            bool detectedEqualSign = false;
+            char equalSign = config.equalSign;
+            
+            int i=startIndex;
+            while(i<text.Length)
+            {
+                //string block, [[ ]] " '
+                if (!lineComment && !blockComment)
+                {
+                    if (blockStringString || blockStringChar)
+                    {
+                        //escape char for displaying " and ' char in string area
+                        if(text[i]==escapeCharSign)
+                        {
+                            if (!isEscapeCharNow)
+                            {
+                                blockStringCount = 0;
+                                
+                                isEscapeCharNow=true;
+                                
+                                i++;
+                                continue;
+                            }
+                            isEscapeCharNow=false;
+                        }
+                    }
+                    
+                    if (!isEscapeCharNow && !blockStringChar)
+                    {
+                        if (blockStringString)
+                        {
+                            if (text[i]==blockStringClose[blockStringCount])
+                            {                                
+                                blockStringCount++;
+                                if (blockStringCount==blockStringClose.Length)
+                                {
+                                    blockStringString=false;
+                                    blockStringCount=0;
+                                    
+                                    UndoCaptureThisChar(blockStringClose[0],detectedEqualSign,ref capturedValue1,ref capturedValue2);
+
+                                    i++;
+                                    continue;
+                                }
+                            }else
+                                blockStringCount=0;
+                        }else
+                        {
+                            if (text[i]==blockStringOpen[blockStringCount])
+                            {    
+                                blockStringCount++;
+                                if (blockStringCount==blockStringOpen.Length)
+                                {
+                                    blockStringString=true;
+                                    blockStringCount=0;
+                                    
+                                    UndoCaptureThisChar(blockStringOpen[0],detectedEqualSign,ref capturedValue1,ref capturedValue2);
+
+                                    i++;
+                                    continue;
+                                }
+                            }else
+                                blockStringCount=0;
+                        }
+                    }
+                    
+                    if (!isEscapeCharNow && !blockStringString)
+                    {
+                        if(blockStringChar)
+                        {
+                            if (text[i]==stringChars[stringCharType])
+                            {
+                                blockStringChar=false;
+                                
+                                i++;
+                                continue;
+                            }
+                        }else
+                        {
+                            if (text[i]==stringChars[0])
+                            {
+                                blockStringChar=true;
+                                stringCharType = 0;
+                                
+                                i++;
+                                continue;
+                            }else if (text[i]==stringChars[1])
+                            {
+                                blockStringChar=true;
+                                stringCharType = 1;
+                                
+                                i++;
+                                continue;
+                            }
+                        }
+                    }
+                    
+                    if (blockStringString || blockStringChar)
+                    {
+                        char newChar = text[i];
+                        
+                        if (isEscapeCharNow && text[i]=='n') //newline
+                            newChar = '\n';
+                        isEscapeCharNow = false;
+                        
+                        CaptureChar(newChar,detectedEqualSign,ref capturedValue1,ref capturedValue2);
+                        
+                        i++;
+                        continue;
+                    }
+                }
+                
+                //connector between string value, "..."
+                if (!detectedUnspacedChar && text[i]==stringGlue[0])
+                {
+                    i++;
+                    continue;
+                }
+                
+                //Whitespace
+                if (text[i]==whitespaceA || text[i]==whitespaceB)
+                {
+                    detectedUnspacedChar = false;
+                    
+                    i++;
+                    continue;
+                }
+                
+                //Newline
+                if (text[i]==newLineChar[0] || text[i]==newLineChar[1])
+                {
+                    lineComment = false;
+                    
+                    i++;
+                    continue;
+                }
+                
+                //Block comment
+                if (!blockComment)
+                {    
+                    if (text[i]==blockCommentOpen[blockCommentCount])
+                    {
+                        blockCommentCount++;
+                        if (blockCommentCount==blockCommentOpen.Length)
+                        {
+                            blockComment=true;
+                            blockCommentCount=0;
+                            
+                            i++;
+                            continue;
+                        }
+                    }else
+                        blockCommentCount=0;
+                }else
+                {
+                    if (text[i]==blockCommentClose[blockCommentCount])
+                    {
+                        blockCommentCount++;
+                        if (blockCommentCount==blockCommentClose.Length)
+                        {
+                            blockComment=false;
+                            blockCommentCount=0;
+                            
+                            i++;
+                            continue;
+                        }
+                    }else
+                        blockCommentCount=0;
+                    
+                    i++;
+                    continue;
+                }
+                
+                //Line comment, --
+                if(!lineComment)
+                {
+                    if (text[i]==commentString[commentCharCount])
+                    {
+                        commentCharCount++;
+                        if (commentCharCount==commentString.Length)
+                        {
+                            lineComment=true;
+                            commentCharCount=0;
+                            
+                            UndoCaptureThisChar(commentString[0],detectedEqualSign,ref capturedValue1,ref capturedValue2);
+                            
+                            i++;
+                            continue;
+                        }
+                    }else
+                        commentCharCount=0;
+                }else
+                {
+                    i++;
+                    continue;
+                }
+                
+                //{ and }
+                if (!inTable && text[i]==tableOpen)
+                {
+                    inTable = true;
+                    
+                    i++;
+                    continue;
+                }
+                else if (text[i]==tableOpen)
+                {
+                    int offsetIn = 0;
+                    var list = ParseTable(config,i,text,filePath,out offsetIn);
+                    capturedObject1=list;
+                    
+                    bool saved = SaveKeyValuePair(prefix,contentIndex,capturedValue1,capturedValue2,capturedObject1,filePath,detectedEqualSign,ref contentList);
+                    
+                    capturedValue1 = "";
+			        capturedValue2 = "";
+			        capturedObject1 = null;
+			        detectedEqualSign = false;
+			        
+			        if (saved) contentIndex++;
+                    
+                    i = i+offsetIn;
+                    continue;
+                }
+                else if (text[i]==tableClose)
+                {                 
+                    SaveKeyValuePair(prefix,contentIndex,capturedValue1,capturedValue2,capturedObject1,filePath,detectedEqualSign,ref contentList);
+                    
+                    inTable = false;
+                    offset = (i-startIndex)+1; //is out
+                    return contentList;
+                }
+                if (!inTable)
+                {
+                    i++;
+                    continue;
+                }
+                
+                //content separator, ","
+                if (text[i]==contentSeparator)
+                {                  
+                    bool saved = SaveKeyValuePair(prefix,contentIndex,capturedValue1,capturedValue2,capturedObject1,filePath,detectedEqualSign,ref contentList);
+                            
+			        capturedValue1 = "";
+			        capturedValue2 = "";
+			        capturedObject1 = null;
+			        detectedEqualSign = false;
+			        
+			        if (saved) contentIndex++;
+	        
+                    i++;
+                    continue;
+                }
+                
+                //key value separator, =
+                if (text[i]==equalSign)
+                {
+                    detectedEqualSign = true;
+                    
+                    i++;
+                    continue;
+                }
+                
+                detectedUnspacedChar = true;
+                
+                CaptureChar(text[i],detectedEqualSign,ref capturedValue1,ref capturedValue2);
+
+                i++;
+            }
+            offset = text.Length;
+            return contentList;
+        }
+        
+        private static void CaptureChar(char toCapture, bool detectedEqualSign,ref String capturedValue1,ref String capturedValue2)
+        {
+            if (detectedEqualSign)
+                capturedValue2 = capturedValue2 + toCapture;
+            else
+                capturedValue1 = capturedValue1 + toCapture;
+        }
+        
+        private static void UndoCaptureThisChar(char charToUndo,bool detectedEqualSign,ref String capturedValue1,ref String capturedValue2)
+        {
+            if (detectedEqualSign)
+                capturedValue2 = capturedValue2.TrimEnd(charToUndo);
+            else
+                capturedValue1 = capturedValue1.TrimEnd(charToUndo);
+        }
+
+        private static bool SaveKeyValuePair(String prefix,int contentIndex,String capturedValue1,String capturedValue2,Object capturedObject1,String filePath, bool detectedEqualSign, ref Dictionary<String,Object> contentList)
+        {
+        	capturedValue1 = capturedValue1.Trim(new char[2]{'[',']'});
+        	
+        	if (!detectedEqualSign) //didn't explicitly mention key valu pair
+            {
+        		if (capturedValue1!="" && capturedObject1!=null) //Spring-demo's syntax of a table's name
+        		{
+        			//do nothing
+        		}
+        		else
+        		{
+              		capturedValue2 = capturedValue1;
+              		capturedValue1 = prefix + contentIndex;
+        		}
+            }
+        	
+            if (capturedValue2!="" || capturedObject1!=null)
+            {   
+                bool duplicate = false;
+                if(contentList.ContainsKey(capturedValue1))
+                {
+                    duplicate = true;
+                    System.Diagnostics.Trace.TraceWarning("CrudeLUAReader: detected duplicate value in " + filePath + " : " + capturedValue1 + "="+ contentList[capturedValue1]);
+                }
+
+                if (capturedObject1==null)
+                {
+                    if(duplicate) 
+                        contentList[capturedValue1] = capturedValue2;
+                    else
+                        contentList.Add(capturedValue1,capturedValue2);
+                }
+                else
+                {
+                    if(duplicate)
+                        contentList[capturedValue1]=capturedObject1;
+                    else
+                        contentList.Add(capturedValue1,capturedObject1);
+                }
+                return true;
+            }
+            return false;
+        }
+	}
+}

--- a/ZeroKLobby/MicroLobby/PlayerListBox.cs
+++ b/ZeroKLobby/MicroLobby/PlayerListBox.cs
@@ -171,16 +171,21 @@ namespace ZeroKLobby.MicroLobby
 		{
 			base.OnMouseMove(e);
 			var cursorPoint = new Point(e.X, e.Y);
+			
 			if (cursorPoint == previousLocation) return;
 			previousLocation = cursorPoint;
-
-			var hoverIndex = IndexFromPoint(cursorPoint);
+			
+			var hoverIndex = IndexFromPoint(cursorPoint); //note: this don't return value exceeding base.Items.Count -1
+			bool isOnEmpty = (hoverIndex >= base.Items.Count-1 && !GetItemRectangle(hoverIndex).Contains(cursorPoint));		
+			
+			if (isOnEmpty) hoverIndex = base.Items.Count; //we'll use this number when cursor is outside the list
+			
 			if (previousHoverIndex == hoverIndex) return;
 			previousHoverIndex = hoverIndex;
 
-			if (hoverIndex < 0 || hoverIndex >= base.Items.Count || !GetItemRectangle(hoverIndex).Contains(cursorPoint))
+			if (hoverIndex < 0 || hoverIndex >= base.Items.Count)
 			{
-				HoverItem = null;
+				HoverItem = null; //outside the list
 				Program.ToolTip.SetUser(this, null);
 			}
 			else

--- a/ZeroKLobby/MicroLobby/TextWindow.cs
+++ b/ZeroKLobby/MicroLobby/TextWindow.cs
@@ -470,9 +470,10 @@ namespace ZeroKLobby.MicroLobby
                 { //remove old text, create space for new text (recycle existing row)
                     int toRemove = (MaxTextLines / 10) + 1; //remove 10% of old text
 
+                    //calculate scrollbar offset:
                     int lineCount = 0;
                     int wrapCount = 0;
-                    while (lineCount < toRemove + 1) //calculate scrollbar offset:
+                    while (lineCount < toRemove + 1)
                     {
                         if (displayLines[wrapCount + lineCount].Previous)
                             wrapCount++;
@@ -482,8 +483,9 @@ namespace ZeroKLobby.MicroLobby
                     int vScrollBarOffset = wrapCount + lineCount - 1;
                     vScrollBarOffset = Math.Min(vScrollBarOffset, vScrollBar.Value - 1);
 
+                    //shift existing texts upward:
                     var x = 0;
-                    for (int i = toRemove; i < totalLines; i++) //shift existing texts upward:
+                    for (int i = toRemove; i < totalLines; i++)
                     {
                         textLines[x].TotalLines = textLines[i].TotalLines;
                         textLines[x].Width = textLines[i].Width;
@@ -492,14 +494,16 @@ namespace ZeroKLobby.MicroLobby
                         x++;
                     }
 
-                    for (var i = totalLines - toRemove; i < MaxTextLines; i++) //fill new space with empty string
+                    //fill new space with empty string
+                    for (var i = totalLines - toRemove; i < MaxTextLines; i++)
                     {
                         textLines[i].TotalLines = 0;
                         textLines[i].Line = "";
                         textLines[i].Width = 0;
                     }
 
-                    totalLines = totalLines - toRemove - 1; //set draw line to new space
+                    //set draw line to new space
+                    totalLines = totalLines - toRemove - 1;
 
                     if (Height != 0)
                     {

--- a/ZeroKLobby/ZeroKLobby.csproj
+++ b/ZeroKLobby/ZeroKLobby.csproj
@@ -135,6 +135,7 @@
       <DependentUpon>PromptForm.cs</DependentUpon>
     </Compile>
     <Compile Include="MicroForms\UnitSyncRetryPrompt.cs" />
+    <Compile Include="MicroLobby\ExtrasTab\TableReader.cs" />
     <Compile Include="MicroLobby\ExtrasTab\SkirmishControlTool.cs" />
     <Compile Include="MicroForms\UnitSyncUploadPrompt.cs" />
     <Compile Include="MicroLobby\HexToUnicodeConverter.cs">


### PR DESCRIPTION
This playerlist fix isn't related to  "refresh spam" or "can't right click" issue, its just other minor clicking/tooltip bug.
  - if cursor move over empty space below the list of player, it won't always show tooltip of the last player in the list anymore 

Skirmish Tab:
  - move my LUA table reader code into new file, trying to use it with other Form later.
  - fix rapid clicking in Skirmisher playerlist not reliable/not-consistent/clumsy
  - auto set Engine & Game to default version at first start




