### PR TITLE
ZKL PlayerListBox: fix issue # 441 (miscalculate playerlist size in MONO)

### DIFF
--- a/ZeroKLobby/MicroLobby/PlayerListBox.cs
+++ b/ZeroKLobby/MicroLobby/PlayerListBox.cs
@@ -16,6 +16,14 @@ namespace ZeroKLobby.MicroLobby
 	    ObservableCollection<PlayerListItem> realItems;
 	    Timer timer;
 	    public PlayerListItem HoverItem { get; set; }
+        public override int ItemHeight{
+            get {
+                DpiMeasurement.DpiXYMeasurement(this);
+                if (DesignMode || base.Items.Count==0) return 10;
+                return DpiMeasurement.ScaleValueY(((PlayerListItem)base.Items[0]).Height); //in MONO the ListBox's size doesn't seem to be calculated from OnMeasureItem() but from ItemHeight property, so we return the size here for MONO compatibility
+            }
+        }
+
 		public bool IsBattle { get; set; }
 	    const int stagingMs = 200; // staging only on linux
 	    DateTime lastChange = DateTime.UtcNow;
@@ -48,19 +56,6 @@ namespace ZeroKLobby.MicroLobby
 		            }
 		        };
 		    IntegralHeight = false; //so that the playerlistBox completely fill the edge (not snap to some item size)
-
-            if (Environment.OSVersion.Platform == PlatformID.Unix)
-            {
-                //dummy item to fix Mono scrollbar always cutout last 3 line
-                //https://bugzilla.novell.com/show_bug.cgi?id=475581
-                DpiMeasurement.DpiXYMeasurement (this);
-                int numberOfDummy = (int)(DpiMeasurement.scaleUpRatioY*3 + 0.9d); //similar to Math.Ceiling(scaleUpRatioY*3)
-
-                for (int i=0; i<numberOfDummy; i++) {
-                    PlayerListItem dummyItem = new PlayerListItem () { isOfflineMode = true, isDummy = true, Height = 1, UserName = "ZZ 99 dummy "+i.ToString() }; //sorted to be last
-                    realItems.Add (dummyItem);
-                }
-            }
 		}
 
 	    void RealItemsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args) {
@@ -163,7 +158,7 @@ namespace ZeroKLobby.MicroLobby
             DpiMeasurement.DpiXYMeasurement(this);
             if (DesignMode) return;
             if (e.Index > -1 && e.Index < base.Items.Count)
-                e.ItemHeight = DpiMeasurement.ScaleValueY(((PlayerListItem)base.Items[e.Index]).Height); //GetItemRectangle() will measure the size of item (for drawing). We return a custom Height defined in PlayerListItems.cs
+                e.ItemHeight = DpiMeasurement.ScaleValueY(((PlayerListItem)base.Items[e.Index]).Height); //GetItemRectangle() will measure the size of item for drawing, so we return a custom Height defined in PlayerListItems.cs
 		}
 
 

--- a/ZeroKLobby/MicroLobby/PlayerListItem.cs
+++ b/ZeroKLobby/MicroLobby/PlayerListItem.cs
@@ -27,10 +27,6 @@ namespace ZeroKLobby.MicroLobby
         public bool isZK = false;
         public UserBattleStatus offlineUserBattleStatus;
         public User offlineUserInfo;
-        /// <summary>
-        /// PlayerListItem will never render or draw any content when this flag is true.
-        /// </summary>
-        public bool isDummy = false;
         public int? AllyTeam { get; set; }
         public BotBattleStatus BotBattleStatus { get; set; }
         public string Button { get; set; }
@@ -99,8 +95,6 @@ namespace ZeroKLobby.MicroLobby
 
         public void DrawPlayerLine(Graphics g, Rectangle bounds, Color foreColor, Color backColor, bool grayedOut, bool isBattle)
         {
-            if (isDummy)
-                return;
 
             g.TextRenderingHint = TextRenderingHint.SystemDefault;
             g.InterpolationMode = InterpolationMode.HighQualityBicubic;


### PR DESCRIPTION
REASON:
PlayerListBox's code didn't obey
https://msdn.microsoft.com/en-us/library/system.windows.forms.listbox.itemheight(v=vs.110).aspx
which says "ItemHeight" must return height of first item in the list when displaying multiple items with variable height (the "DrawOwnerVariable" tag).

Weirdly this omission didn't cause issue in NET (probably in NET the ListBox size is recalculated using value returned from "OnMeasureItem()").

FIX:
Override "ItemHeight" property and return the Height of the first item in the ListBox.
fix #441