### PR TITLE
ZKL PlayerList: clicking behaviour tweak:

### DIFF
--- a/ZeroKLobby/MicroLobby/BattleChatControl.cs
+++ b/ZeroKLobby/MicroLobby/BattleChatControl.cs
@@ -47,7 +47,6 @@ namespace ZeroKLobby.MicroLobby
 			if (Program.TasClient.MyBattle != null) foreach (var user in Program.TasClient.MyBattle.Users.Values) AddUser(user.Name);
 			ChatLine += (s, e) => { if (Program.TasClient.IsLoggedIn) Program.TasClient.Say(SayPlace.Battle, null, e.Data, false); };
 			playerBox.IsBattle = true;
-			playerBox.MouseDown += playerBox_MouseDown;
 
             minimapFuncBox = new ZeroKLobby.Controls.MinimapFuncBox();
 
@@ -359,7 +358,7 @@ namespace ZeroKLobby.MicroLobby
 			}
 		}
 
-		void playerBox_MouseDown(object sender, MouseEventArgs mea)
+		protected override void PlayerBox_MouseClick(object sender, MouseEventArgs mea)
 		{
 			if (mea.Button == MouseButtons.Left)
 			{
@@ -384,6 +383,7 @@ namespace ZeroKLobby.MicroLobby
 				    } finally {
 				        Program.ToolTip.Visible = true;
 				    }
+					return;
 				}
                 //NOTE: code that display player's context menu on Left-mouse-click is in ChatControl.playerBox_MouseClick();
 			}
@@ -401,6 +401,7 @@ namespace ZeroKLobby.MicroLobby
 				    } finally {
 				        Program.ToolTip.Visible = true;
 				    }
+					return;
 				}
 				/*
 					if (playerBox.HoverItem.UserBattleStatus != null) {
@@ -411,6 +412,7 @@ namespace ZeroKLobby.MicroLobby
 						Program.ToolTip.Visible = true;
 					}*/
 			}
+			base.PlayerBox_MouseClick(sender, mea);
 		}
 
         private void InitializeComponent()

--- a/ZeroKLobby/MicroLobby/ChatControl.Designer.cs
+++ b/ZeroKLobby/MicroLobby/ChatControl.Designer.cs
@@ -125,8 +125,6 @@ namespace ZeroKLobby.MicroLobby
             this.playerBox.Name = "playerBox";
             this.playerBox.Size = new System.Drawing.Size(326, 545);
             this.playerBox.TabIndex = 1;
-            this.playerBox.MouseClick += new System.Windows.Forms.MouseEventHandler(this.playerBox_MouseClick);
-            this.playerBox.DoubleClick += new System.EventHandler(this.playerBox_DoubleClick);
             // 
             // sendBox
             // 

--- a/ZeroKLobby/MicroLobby/ChatControl.cs
+++ b/ZeroKLobby/MicroLobby/ChatControl.cs
@@ -17,11 +17,12 @@ namespace ZeroKLobby.MicroLobby
     {
         ZKLMouseClick playerBox_zklclick = new ZKLMouseClick();
 
-        protected bool filtering;
+        protected bool filtering; //playerList filter
         bool mouseIsDown;
         readonly PlayerListItem notResultsItem = new PlayerListItem { Title = "No match", SortCategory = 3 };
         protected List<PlayerListItem> playerListItems = new List<PlayerListItem>();
         readonly PlayerListItem searchResultsItem = new PlayerListItem { Title = "Search results", SortCategory = 1 };
+        
         public bool CanLeave { get { return ChannelName != "Battle"; } }
         public static EventHandler<ChannelLineArgs> ChannelLineAdded = (sender, args) => { };
         Timer minuteTimer;
@@ -447,7 +448,7 @@ namespace ZeroKLobby.MicroLobby
         //using MouseUp because it allow the PlayerBox's "HoverItem" to show correct value when rapid clicking
         protected virtual void PlayerBox_MouseClick(object sender, MouseEventArgs mea) //from BattleChatControl
         {
-            if (playerBox_zklclick.clickCount % 2 == 0) 
+            if (playerBox_zklclick.clickCount >= 2) 
             { //Double click
                 var playerListItem = playerBox.SelectedItem as PlayerListItem;
                 if (playerListItem != null && playerListItem.User != null)
@@ -502,8 +503,9 @@ namespace ZeroKLobby.MicroLobby
         }
 
         /// <summary>
-        /// Reimplement regular MouseClick event to add Right-button event and to create a consistent 
-        /// click behaviour for MONO (so that its similar to the one in NET)
+        /// A reimplementation of regular MouseClick event using MouseDown & MouseUp pair which can be used
+        /// for the specific aim of delaying a click event until MouseUp, or/and to read Right-click event for
+        /// NET's Control which didn't allow them (such as ListBox), or/and to simply count successive clicks.
         /// </summary>
         public class ZKLMouseClick
         {

--- a/ZeroKLobby/MicroLobby/PlayerListBox.cs
+++ b/ZeroKLobby/MicroLobby/PlayerListBox.cs
@@ -161,10 +161,28 @@ namespace ZeroKLobby.MicroLobby
                 e.ItemHeight = DpiMeasurement.ScaleValueY(((PlayerListItem)base.Items[e.Index]).Height); //GetItemRectangle() will measure the size of item for drawing, so we return a custom Height defined in PlayerListItems.cs
 		}
 
+        bool mouseIsDown = false;
+        protected override void OnMouseDown(MouseEventArgs e)
+        {
+            base.OnMouseDown(e);
+            mouseIsDown = true;
+            UpdateHoverItem(e);
+        }
+
+        protected override void OnMouseUp(MouseEventArgs e)
+        {
+            base.OnMouseUp (e);
+            mouseIsDown = false;
+        }
 
 		protected override void OnMouseMove(MouseEventArgs e)
 		{
 			base.OnMouseMove(e);
+			if (!mouseIsDown) UpdateHoverItem(e);
+		}
+
+		void UpdateHoverItem(MouseEventArgs e)
+		{
 			var cursorPoint = new Point(e.X, e.Y);
 			
 			if (cursorPoint == previousLocation) return;


### PR DESCRIPTION
replace current MouseClick event with MouseUp/Down pair.

This is to address the following
  1) PlayerList "HoverItem" require time to update properly after each MouseDown (or rapid click will cause clumsy behaviour). So MouseDown in BattleChatControl.cs is replaced with MouseDown/Up pair.
  2) Right-click for MouseClick event don't exist in NET but exist in MONO. So replacing with MouseDown/Up make it consistent in both platform

Expected Benefit:
In effect user should perceive the clicking on playerlist to be more robust. Meaning: it always open Context-menu for correct username and work for both mouse button, 