### PR TITLE
Springie: fix VoteResign & VoteExit crash Springie if player exited lobby

### DIFF
--- a/Springie/Springie/autohost/AutoHost.cs
+++ b/Springie/Springie/autohost/AutoHost.cs
@@ -201,6 +201,11 @@ namespace Springie.autohost
 
 
         public int GetUserLevel(TasSayEventArgs e) {
+            if (!tas.ExistingUsers.ContainsKey(e.UserName))
+            {
+                Respond(e, string.Format("Please connect to lobby for right verification"));
+                return 0; //1 is default, but we return 0 to avoid right abuse (by Disconnecting from Springie and say thru Spring)
+            }
             return GetUserLevel(e.UserName);
         }
 

--- a/Springie/Springie/autohost/Polls/VoteExit.cs
+++ b/Springie/Springie/autohost/Polls/VoteExit.cs
@@ -21,7 +21,10 @@ namespace Springie.autohost.Polls
                 {
                     if (p.IsIngame || tas.MyBattle.Users.ContainsKey(p.Name))
                     {
-                        if (!tas.ExistingUsers[p.Name].IsAway) cnt++;
+                        //Note: "ExistingUsers" is empty if users disconnected from lobby but still ingame.
+
+                        bool afk = tas.ExistingUsers.ContainsKey(p.Name) && tas.ExistingUsers[p.Name].IsAway;
+                        if (!afk) cnt++;
                     }
                 }
                 winCount = cnt / 2 + 1;

--- a/Springie/Springie/autohost/Polls/VoteResign.cs
+++ b/Springie/Springie/autohost/Polls/VoteResign.cs
@@ -23,7 +23,10 @@ namespace Springie.autohost.Polls
                     {
                         if (p.IsIngame || tas.MyBattle.Users.ContainsKey(p.Name))
                         {
-                            if (!tas.ExistingUsers[p.Name].IsAway) cnt++;
+                            //Note: "ExistingUsers" is empty if users disconnected from lobby but still ingame.
+
+                            bool afk = tas.ExistingUsers.ContainsKey(p.Name) && tas.ExistingUsers[p.Name].IsAway;
+                            if (!afk) cnt++;
                         }
                     }
                     winCount = cnt / 2 + 1;


### PR DESCRIPTION
Disconnected player can still communicate with Springie thru Spring. So, when Springie tries to get AFK status of exited player for vote, it crash because of "KeyNotFoundException"
(I saw this in springie log, from server). 


Fix https://github.com/ZeroK-RTS/Zero-K-Infrastructure/issues/427

