### PR TITLE
Springie: undo adding message to tell player to reconnect to lobby

### DIFF
--- a/Springie/Springie/autohost/AutoHost.cs
+++ b/Springie/Springie/autohost/AutoHost.cs
@@ -203,7 +203,7 @@ namespace Springie.autohost
         public int GetUserLevel(TasSayEventArgs e) {
             if (!tas.ExistingUsers.ContainsKey(e.UserName))
             {
-                Respond(e, string.Format("Please connect to lobby for right verification"));
+                //Respond(e, string.Format("{0} please reconnect to lobby for right verification", e.UserName));
                 return 0; //1 is default, but we return 0 to avoid right abuse (by Disconnecting from Springie and say thru Spring)
             }
             return GetUserLevel(e.UserName);


### PR DESCRIPTION
I tested and it sound silly ingame (because its a personal message read by others)