### PR TITLE
remove minimum karma to vote

### DIFF
--- a/Shared/PlasmaShared/GlobalConst.cs
+++ b/Shared/PlasmaShared/GlobalConst.cs
@@ -202,7 +202,7 @@ namespace ZkData
 
         public const int ForumPostsPerPage = 50;
         public const int MinLevelForForumVote = 10;
-        public const int MinNetKarmaToVote = -30;
+        public const int MinNetKarmaToVote = -9999;
         public const int PostVoteHideThreshold = -6;
         public const bool OnlyAdminsSeePostVoters = false;
         public const int PlanetWarsMinutesToAttack = 30;


### PR DESCRIPTION
reasoning:
* causes additional spam of "+1" posts (see #98)
* can be easily circumvented by getting +9001 from a silly gif (eg. http://zero-k.info/Forum/Thread/9847?page=2#108816 )
* is a case of karma being per-user and not per-post (encourages farming etc., same reasoning as why per-user karma isn't shown on the user page)
* extremely toxic cases can be handled with a forum ban instead (eg. http://zero-k.info/users/lobbydetail/paShadoWn )
* is not documented