### PR TITLE
zkl: some null check to fix Chat channel error

### DIFF
--- a/ZeroKLobby/MicroLobby/ToolTabs.cs
+++ b/ZeroKLobby/MicroLobby/ToolTabs.cs
@@ -246,6 +246,9 @@ namespace ZeroKLobby.MicroLobby
 
         private void RemoveTab(string key)
         {   
+            if (!controls.ContainsKey(key))
+                return;
+            
             panel.Controls.Remove(controls[key]);
             controls.Remove(key);
             if (Program.ToolTip != null)


### PR DESCRIPTION
when we add a player as Friend (right/left+click on name - > Friend), the chat channel throw an error "KeyNotFoundException" because it tries to close and then re-open PM channel that might not exist yet.

