### PR TITLE
Springie: ignore leading & trailing whitespace in key = value pair

### DIFF
--- a/Springie/Springie/autohost/AutoHost_commands.cs
+++ b/Springie/Springie/autohost/AutoHost_commands.cs
@@ -1000,8 +1000,8 @@ namespace Springie.autohost
                     Respond(e, "requires key=value format");
                     return ret;
                 }
-                var key = parts[0];
-                var val = parts[1];
+                var key = parts[0].Trim(); //Trim() to make "key = value format" ignore whitespace 
+                var val = parts[1].Trim();
 
                 var found = false;
                 var mod = hostedMod;


### PR DESCRIPTION
this should make setting modoption not sensitive to whitespace in between "=" and "," (in case player attempted to type it manually & didn't use ZKL to set options)

reported in https://github.com/ZeroK-RTS/Zero-K-Infrastructure/issues/500