### PR TITLE
Springie: fix buggy !setengine issue

### DIFF
--- a/Shared/PlasmaDownloader/PlasmaDownloader.cs
+++ b/Shared/PlasmaDownloader/PlasmaDownloader.cs
@@ -68,18 +68,25 @@ namespace PlasmaDownloader
             packageDownloader.Dispose();
         }
 
-        public Download GetAndSwitchEngine(string version) {
+        /// <summary>
+        /// Download requested Spring version, then call SetEnginePath() after finishes.
+        /// Parameter "forSpringPaths" allow you to set a custom SpringPath for which to call SetEnginePath() 
+        /// on behalf off (is useful for Autohost which run multiple Spring version but is sharing single downloader)
+        /// </summary>
+        public Download GetAndSwitchEngine(string version, SpringPaths forSpringPaths=null ) {
+            if (forSpringPaths == null) 
+                forSpringPaths = SpringPaths;
             lock (downloads) {
                 downloads.RemoveAll(x => x.IsAborted || x.IsComplete != null); // remove already completed downloads from list}
                 var existing = downloads.SingleOrDefault(x => x.Name == version);
                 if (existing != null) return existing;
 
                 if (SpringPaths.HasEngineVersion(version)) {
-                    SpringPaths.SetEnginePath(SpringPaths.GetEngineFolderByVersion(version));
+                    forSpringPaths.SetEnginePath(SpringPaths.GetEngineFolderByVersion(version));
                     return null;
                 }
                 else {
-                    var down = new EngineDownload(version, SpringPaths);
+                    var down = new EngineDownload(version, forSpringPaths);
                     downloads.Add(down);
                     DownloadAdded.RaiseAsyncEvent(this, new EventArgs<Download>(down));
                     down.Start();

--- a/Springie/Springie/autohost/AutoHost.cs
+++ b/Springie/Springie/autohost/AutoHost.cs
@@ -64,9 +64,9 @@ namespace Springie.autohost
             string version = config.SpringVersion ?? Program.main.Config.SpringVersion ?? GlobalConst.DefaultEngineOverride;
             springPaths = new SpringPaths(Program.main.paths.GetEngineFolderByVersion(version), Program.main.Config.DataDir);
             
-            Program.main.paths.SpringVersionChanged += (s, e) =>
+            springPaths.SpringVersionChanged += (s, e) =>
                 {
-                    if (!String.IsNullOrEmpty(requestedEngineChange) && requestedEngineChange == Program.main.paths.SpringVersion) {
+                    if (!String.IsNullOrEmpty(requestedEngineChange) && requestedEngineChange == springPaths.SpringVersion) {
                         config.SpringVersion = requestedEngineChange;
                         springPaths.SetEnginePath(Program.main.paths.GetEngineFolderByVersion(requestedEngineChange));
                         requestedEngineChange = null;
@@ -667,7 +667,7 @@ namespace Springie.autohost
             //cache.GetMap(mapname, (m, x, y, z) => { mapi = m; }, (e) => { }, springPaths.SpringVersion);
             //int mint, maxt;
             if (!springPaths.HasEngineVersion(engine)) {
-                Program.main.Downloader.GetAndSwitchEngine(engine);
+                Program.main.Downloader.GetAndSwitchEngine(engine,springPaths);
             } else {
                 springPaths.SetEnginePath(springPaths.GetEngineFolderByVersion(engine));
             }

--- a/Springie/Springie/autohost/AutoHost_commands.cs
+++ b/Springie/Springie/autohost/AutoHost_commands.cs
@@ -1231,7 +1231,7 @@ namespace Springie.autohost
                     }
                     requestedEngineChange = specificVer; //in autohost.cs
                     Respond(e, "Preparing engine change to " + specificVer);
-                    var springCheck = Program.main.Downloader.GetAndSwitchEngine(specificVer);
+                    var springCheck = Program.main.Downloader.GetAndSwitchEngine(specificVer,springPaths);//will trigger springPaths.SpringVersionChanged event
                     if (springCheck == null) ; //Respond(e, "Engine available");
                     else
                         Respond(e, "Downloading engine. " + springCheck.IndividualProgress + "%");


### PR DESCRIPTION
Setengine normally occur when a global "SpringPaths" call a "SpringVersionChanged" event to all Autohost at same time. This work perfectly fine if we wanted to change engine for all Autohost at same time, but !setengine is coded to effect only a single Autohost. As result since "SpringVersionChanged" was called only once per !setengine, it won't get called again when commanded in other Autohost.

The fix is to tell each Autohost to use its own "SpringVersionChanged" event from local "SpringPaths" (already present in the code). This immediately fix https://github.com/ZeroK-RTS/Zero-K-Infrastructure/issues/243

Have done some test.