### PR TITLE
Zkl & ZklNET4.0: won't use "tooltip Always on top" fix in Linux

### DIFF
--- a/ZeroKLobby/ToolTips/ToolTipHandler.cs
+++ b/ZeroKLobby/ToolTips/ToolTipHandler.cs
@@ -189,8 +189,11 @@ namespace ZeroKLobby
                         ny = mp.Y - tooltip.Height - 8;
                     }
 
-                    SetWindowPos(tooltip.Handle, HWND_TOPMOST, 0, 0, 0, 0, SWP_ToolTipOption); //refresh tooltip's Z-order to be on top
-                    tooltip.SetDesktopLocation(nx, ny); //note: SetWindowPos() positioning won't work in Linux (so we shouldn't replace this with SetWindowPos)
+                    if (Environment.OSVersion.Platform != PlatformID.Unix)
+                    {
+                        SetWindowPos(tooltip.Handle, HWND_TOPMOST, 0, 0, 0,0, SWP_ToolTipOption); //refresh tooltip's Z-order to be on top
+                    }
+                    tooltip.SetDesktopLocation(nx, ny); 
 
                     var newSize = tooltip.GetTooltipSize();
                     if (newSize.HasValue && newSize.Value != tooltip.Size) tooltip.Size = newSize.Value;

--- a/ZeroKLobby_NET4.0/ToolTips/ToolTipHandler.cs
+++ b/ZeroKLobby_NET4.0/ToolTips/ToolTipHandler.cs
@@ -189,8 +189,11 @@ namespace ZeroKLobby
                         ny = mp.Y - tooltip.Height - 8;
                     }
 
-                    SetWindowPos(tooltip.Handle, HWND_TOPMOST, 0, 0, 0, 0, SWP_ToolTipOption); //refresh tooltip's Z-order to be on top
-                    tooltip.SetDesktopLocation(nx, ny); //note: SetWindowPos() positioning won't work in Linux (so we shouldn't replace this with SetWindowPos)
+                    if (Environment.OSVersion.Platform != PlatformID.Unix)
+                    {
+                        SetWindowPos(tooltip.Handle, HWND_TOPMOST, 0, 0,0,0, SWP_ToolTipOption); //refresh tooltip's Z-order to be on top
+                    }
+                    tooltip.SetDesktopLocation(nx, ny);
 
                     var newSize = tooltip.GetTooltipSize();
                     if (newSize.HasValue && newSize.Value != tooltip.Size) tooltip.Size = newSize.Value;


### PR DESCRIPTION
because user32.dll not found exception in Linux Fedora

hopefully fix: https://github.com/ZeroK-RTS/Zero-K-Infrastructure/issues/521

I have uploaded zklNet4.0 version to server