### PR TITLE
Forget password when user logs out.

### DIFF
--- a/ZeroKLobby/ActionHandler.cs
+++ b/ZeroKLobby/ActionHandler.cs
@@ -159,6 +159,7 @@ namespace ZeroKLobby
                     case "logout":
                         Program.TasClient.RequestDisconnect();
                         Program.Conf.LobbyPlayerName = "";
+                        Program.Conf.LobbyPlayerPassword = "";
                         Program.ConnectBar.TryToConnectTasClient();
                         break;
 

--- a/ZeroKLobby/NavigationControl.cs
+++ b/ZeroKLobby/NavigationControl.cs
@@ -336,6 +336,7 @@ namespace ZeroKLobby
         {
             Program.TasClient.RequestDisconnect();
             Program.Conf.LobbyPlayerName = "";
+            Program.Conf.LobbyPlayerPassword = "";
         }
 
 


### PR DESCRIPTION
Forget password when user logs out. Not doing that is a security issue because the password is stored in plain text and the user name can easily be recovered from the logs of the lobby and engine.