### PR TITLE
Ask if user wants desktop icon and prevent potential race on first start

### DIFF
--- a/ZeroKLobby/Program.cs
+++ b/ZeroKLobby/Program.cs
@@ -177,13 +177,6 @@ namespace ZeroKLobby
 
 
 
-                if (Conf.IsFirstRun)
-                {
-                    Utils.CreateDesktopShortcut();
-                    if (Environment.OSVersion.Platform != PlatformID.Unix)
-                        Utils.RegisterProtocol();
-                }
-
                 SpringPaths = new SpringPaths(null, writableFolderOverride: contentDir);
                 SpringPaths.MakeFolders();
                 SpringPaths.SetEnginePath(Utils.MakePath(SpringPaths.WritableDirectory, "engine", ZkData.GlobalConst.DefaultEngineOverride ?? TasClient.ServerSpringVersion));
@@ -227,6 +220,17 @@ namespace ZeroKLobby
                     }
                 }
                 catch (AbandonedMutexException) { }
+
+                if (Conf.IsFirstRun)
+                {
+                    DialogResult result = MessageBox.Show("Create a desktop icon for Zero-K?", "Zero-K", MessageBoxButtons.YesNo);
+                    if (result == DialogResult.Yes) 
+                    {
+                        Utils.CreateDesktopShortcut();
+                    }
+                    if (Environment.OSVersion.Platform != PlatformID.Unix)
+                        Utils.RegisterProtocol();
+                }
 
                 FriendManager = new FriendManager();
                 AutoJoinManager = new AutoJoinManager();


### PR DESCRIPTION
Ask if user wants desktop icon (some users may not want it). Also, do first run tasks only if this instance is the single instance alive. Otherwise, multiple instances may execute the first run tasks when started repeatedly in rapid succession.