### PR TITLE
ZKL: fix intermittent default engine issue.

### DIFF
--- a/ZeroKLobby/Program.cs
+++ b/ZeroKLobby/Program.cs
@@ -385,7 +385,8 @@ namespace ZeroKLobby
                 return;
 
             // download primary game after rapid list have been downloaded and MainWindow is visible
-            Downloader.GetAndSwitchEngine(GlobalConst.DefaultEngineOverride ?? TasClient.ServerSpringVersion);
+            if (!Utils.VerifySpringInstalled(false))
+                Downloader.GetAndSwitchEngine(GlobalConst.DefaultEngineOverride ?? TasClient.ServerSpringVersion);
             var defaultTag = KnownGames.GetDefaultGame().RapidTag;
             if (!Downloader.PackageDownloader.SelectedPackages.Contains(defaultTag))
             {

--- a/ZeroKLobby/Utils.cs
+++ b/ZeroKLobby/Utils.cs
@@ -304,12 +304,13 @@ namespace ZeroKLobby
         }
 
 
-        public static bool VerifySpringInstalled() {
+        public static bool VerifySpringInstalled(bool showMessageBox = true) {
             if (Program.SpringPaths.SpringVersion == null || !Program.SpringPaths.HasEngineVersion(Program.SpringPaths.SpringVersion)) {
-                MessageBox.Show("Cannot start yet, please wait until engine downloads",
-                                "Engine not prepared yet",
-                                MessageBoxButtons.OK,
-                                MessageBoxIcon.Information);
+                if (showMessageBox)
+                    MessageBox.Show("Cannot start yet, please wait until engine downloads",
+                                    "Engine not prepared yet",
+                                    MessageBoxButtons.OK,
+                                    MessageBoxIcon.Information);
                 return false;
             }
             else return true;


### PR DESCRIPTION
should fix https://github.com/ZeroK-RTS/Zero-K-Infrastructure/issues/529

Is caused by an engine check which always reset engine to default

The origin of bug: 
https://github.com/ZeroK-RTS/Zero-K-Infrastructure/commit/39e1de345d5e41e4f7052133441f45dc32f8cd5b , an irregular behaviour noted in #529 is due to it using "PackageDownloaded" event as delay, which is after ZKL finish downloading Rapid list from server at startup.