### PR TITLE
Voteresign: count afkers to success limit

### DIFF
--- a/Springie/Springie/autohost/Polls/VoteResign.cs
+++ b/Springie/Springie/autohost/Polls/VoteResign.cs
@@ -18,18 +18,7 @@ namespace Springie.autohost.Polls
                 if (voteStarter != null)
                 {
                     question = string.Format("Resign team {0}?", voteStarter.AllyID + 1);
-                    int cnt = 0;
-                    foreach (var p in context.Players.Where(x => x.AllyID == voteStarter.AllyID && !x.IsSpectator))
-                    {
-                        if (p.IsIngame || tas.MyBattle.Users.ContainsKey(p.Name))
-                        {
-                            //Note: "ExistingUsers" is empty if users disconnected from lobby but still ingame.
-
-                            bool afk = tas.ExistingUsers.ContainsKey(p.Name) && tas.ExistingUsers[p.Name].IsAway;
-                            if (!afk) cnt++;
-                        }
-                    }
-                    winCount = cnt / 2 + 1;
+                    winCount = context.Players.Count(x => x.AllyID == voteStarter.AllyID && !x.IsSpectator) / 2 + 1;
                     return true;
                 }
             }


### PR DESCRIPTION
Using the afk status is a bad way of discounting people because it's unreliable.
For example Springie can force people to afk if they arent present when game is forced but they arent actually afk.
Or people who were really afk just came back.
Most important in 2v2 when one partner being falsely afk can make resign require only 1 vote ( see #395 ).
fixes #395
fixes #474