### PR TITLE
Battle details page: show real time for dead message

### DIFF
--- a/Shared/LobbyClient/Spring.cs
+++ b/Shared/LobbyClient/Spring.cs
@@ -550,7 +550,7 @@ namespace LobbyClient
 
         private void StatsMarkDead(string name, bool isDead) {
             BattlePlayerResult sp;
-            if (statsPlayers.TryGetValue(name, out sp)) sp.LoseTime = isDead ? (int)DateTime.UtcNow.Subtract(battleResult.StartTime).TotalSeconds : (int?)null;
+            if (statsPlayers.TryGetValue(name, out sp)) sp.LoseTime = isDead ? (int)DateTime.UtcNow.Subtract(battleResult.IngameStartTime ?? battleResult.StartTime).TotalSeconds : (int?)null;
         }
 
         private void process_ErrorDataReceived(object sender, DataReceivedEventArgs e) {


### PR DESCRIPTION
"X died in 123 seconds" uses ingame time now (same as duration).