### PR TITLE
Use proper "away" icon by default (UNTESTED!)

### DIFF
--- a/ZeroKLobby/ZklResources.resx
+++ b/ZeroKLobby/ZklResources.resx
@@ -215,10 +215,10 @@
     <value>Resources\lock.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="away" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>Resources\PlayerStates\away.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>Resources\PlayerStates\away.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="away1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>Resources\PlayerStates\away.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>Resources\PlayerStates\away.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="quickmatch_off" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\PlayerStates\quickmatch_off.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>


### PR DESCRIPTION
I just switched <data name="away"... and <data name="away1"....'s files: away.bmp and away.png
For reference, both away files are located in https://github.com/ZeroK-RTS/Zero-K-Infrastructure/tree/master/ZeroKLobby/Resources/PlayerStates

"away" is used by ZKL for the grey zZs displayed on afk users while "away1" is defined, but doesn't appear to be used for anything, see this search result:
https://github.com/ZeroK-RTS/Zero-K-Infrastructure/search?utf8=%E2%9C%93&q=away1

The .png version looks much better than the .bmp version and on top of that supports transparency. Here's an example picture I made with Paint that shows both the old and new away icons (see bottom right):
![zkl betterafkicon](https://cloud.githubusercontent.com/assets/132906/6926947/3f2af34a-d7ea-11e4-92dd-cc7aea663cb4.png)


NOTE: This change is untested. I don't have any idea how2code zkl and just used the search options to find snippets of code that I swapped.