### PR TITLE
Revert "Use proper "away" icon by default (UNTESTED!)"

### DIFF
--- a/ZeroKLobby/ZklResources.resx
+++ b/ZeroKLobby/ZklResources.resx
@@ -215,10 +215,10 @@
     <value>Resources\lock.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="away" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>Resources\PlayerStates\away.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>Resources\PlayerStates\away.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="away1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>Resources\PlayerStates\away.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>Resources\PlayerStates\away.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="quickmatch_off" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\PlayerStates\quickmatch_off.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>


### PR DESCRIPTION
Reverts ZeroK-RTS/Zero-K-Infrastructure#571
Turn out both icon is used in different places. So swapping is not good.
Will redo this by adding transparency to the icon later.
