### PR TITLE
Zkl: playerlist search fix/ improvement

### DIFF
--- a/ZeroKLobby/MicroLobby/BattleChatControl.cs
+++ b/ZeroKLobby/MicroLobby/BattleChatControl.cs
@@ -132,20 +132,20 @@ namespace ZeroKLobby.MicroLobby
 			{
 				var missionSlot = GetSlotByTeamID(bot.TeamNumber);
 				newList.Add(new PlayerListItem
-				            { BotBattleStatus = bot, SortCategory = bot.AllyNumber*2 + 1, AllyTeam = bot.AllyNumber, MissionSlot = missionSlot });
+				            { BotBattleStatus = bot, SortCategory = bot.AllyNumber * 2 + 1 + (int)PlayerListItem.SortCats.Uncategorized, AllyTeam = bot.AllyNumber, MissionSlot = missionSlot });
 				existingTeams.Add(bot.AllyNumber);
 			}
 
 			// add section headers
 		    if (Program.TasClient.MyBattle.IsQueue)
 		    {
-                newList.Add(new PlayerListItem { Button = "Spectators", SortCategory = 100, IsSpectatorsTitle = true, Height = 25 });
-                newList.Add(new PlayerListItem { Button = "Queued players", SortCategory = 0, AllyTeam = 0, IsSpectatorsTitle = false, Height = 25 });
+                newList.Add(new PlayerListItem { Button = "Spectators", SortCategory = (int)PlayerListItem.SortCats.SpectatorTitle, IsSpectatorsTitle = true, Height = 25 });
+                newList.Add(new PlayerListItem { Button = "Queued players", SortCategory = (int)PlayerListItem.SortCats.QueueTitle, AllyTeam = 0, IsSpectatorsTitle = false, Height = 25 });
 		        newList = newList.OrderBy(x => x.UserName).ToList();
 		    }
 		    else
 		    {
-		        if (PlayerListItems.Any(i => i.UserBattleStatus != null && i.UserBattleStatus.IsSpectator)) newList.Add(new PlayerListItem { Button = "Spectators", SortCategory = 100, IsSpectatorsTitle = true, Height = 25 });
+		        if (PlayerListItems.Any(i => i.UserBattleStatus != null && i.UserBattleStatus.IsSpectator)) newList.Add(new PlayerListItem { Button = "Spectators", SortCategory = (int)PlayerListItem.SortCats.SpectatorTitle, IsSpectatorsTitle = true, Height = 25 });
 
 		        var buttonTeams = existingTeams.Distinct();
 		        if (missionSlots != null) buttonTeams = buttonTeams.Concat(missionSlots.Select(s => s.AllyID)).Distinct();
@@ -161,7 +161,7 @@ namespace ZeroKLobby.MicroLobby
 		                var slot = missionSlots.FirstOrDefault(s => s.AllyID == team);
 		                if (slot != null) allianceName = slot.AllyName;
 		            }
-		            newList.Add(new PlayerListItem { Button = allianceName, SortCategory = team*2, AllyTeam = team, Height = 25 });
+		            newList.Add(new PlayerListItem { Button = allianceName, SortCategory = team * 2 + (int)PlayerListItem.SortCats.Uncategorized, AllyTeam = team, Height = 25 });
 		        }
 
 		        newList = newList.OrderBy(x => x.ToString()).ToList();
@@ -330,6 +330,8 @@ namespace ZeroKLobby.MicroLobby
                 minimapFuncBox.Visible = false; //hide buttons when leaving game 
 				playerListItems.Clear();
 				playerBox.Items.Clear();
+				filtering = false;
+				playerSearchBox.Text = string.Empty;
 			}
 			if (PlayerListItems.Any(i => i.UserName == userName))
 			{

--- a/ZeroKLobby/MicroLobby/ChatControl.Designer.cs
+++ b/ZeroKLobby/MicroLobby/ChatControl.Designer.cs
@@ -257,7 +257,7 @@ namespace ZeroKLobby.MicroLobby
         protected Panel playerBoxSearchBarContainer;
         public PlayerListBox playerBox;
         private Panel searchBarContainer;
-        private TextBox playerSearchBox;
+        protected TextBox playerSearchBox;
         private Panel topicPanel;
         private BitmapButton hideButton;
         private ChatBox topicBox;

--- a/ZeroKLobby/MicroLobby/ExtrasTab/SkirmishControl.cs
+++ b/ZeroKLobby/MicroLobby/ExtrasTab/SkirmishControl.cs
@@ -472,13 +472,13 @@ namespace ZeroKLobby.MicroLobby.ExtrasTab
                 for (int i = 0; i < botsMissionSlot.Count; i++)
                 {
                     BotBattleStatus bot = Bots[i];
-                    newList.Add(new PlayerListItem { BotBattleStatus = bot, SortCategory = bot.AllyNumber * 2 + 1, AllyTeam = bot.AllyNumber, MissionSlot = botsMissionSlot[i] });
+                    newList.Add(new PlayerListItem { BotBattleStatus = bot, SortCategory = bot.AllyNumber * 2 + 1 + (int)PlayerListItem.SortCats.Uncategorized, AllyTeam = bot.AllyNumber, MissionSlot = botsMissionSlot[i] });
                     existingTeams.Add(bot.AllyNumber);
                 }
                 for (int i = botsMissionSlot.Count; i < Bots.Count; i++) //include any extra bots added by user
                 {
                     BotBattleStatus bot = Bots[i];
-                    newList.Add(new PlayerListItem { BotBattleStatus = bot, SortCategory = bot.AllyNumber * 2 + 1, AllyTeam = bot.AllyNumber, MissionSlot = null });
+                    newList.Add(new PlayerListItem { BotBattleStatus = bot, SortCategory = bot.AllyNumber * 2 + 1 + (int)PlayerListItem.SortCats.Uncategorized, AllyTeam = bot.AllyNumber, MissionSlot = null });
                     existingTeams.Add(bot.AllyNumber);
                 }
             }
@@ -487,13 +487,13 @@ namespace ZeroKLobby.MicroLobby.ExtrasTab
                 for (int i = 0; i < Bots.Count; i++)
                 {
                     BotBattleStatus bot = Bots[i];
-                    newList.Add(new PlayerListItem { BotBattleStatus = bot, SortCategory = bot.AllyNumber * 2 + 1, AllyTeam = bot.AllyNumber, MissionSlot = null });
+                    newList.Add(new PlayerListItem { BotBattleStatus = bot, SortCategory = bot.AllyNumber * 2 + 1 + (int)PlayerListItem.SortCats.Uncategorized, AllyTeam = bot.AllyNumber, MissionSlot = null });
                     existingTeams.Add(bot.AllyNumber);
                 }
             }
 
             // add section headers
-            if (playerListItems.Any(i => i.UserBattleStatus != null && i.UserBattleStatus.IsSpectator)) newList.Add(new PlayerListItem { Button = "Spectators", SortCategory = 100, IsSpectatorsTitle = true, Height = 25 });
+            if (playerListItems.Any(i => i.UserBattleStatus != null && i.UserBattleStatus.IsSpectator)) newList.Add(new PlayerListItem { Button = "Spectators", SortCategory = (int)PlayerListItem.SortCats.SpectatorTitle, IsSpectatorsTitle = true, Height = 25 });
 
             var rectangles2 = new Dictionary<int, BattleRect>();
 
@@ -513,7 +513,7 @@ namespace ZeroKLobby.MicroLobby.ExtrasTab
                     var slot = missionSlots.FirstOrDefault(s => s.AllyID == team);
                     if (slot != null) allianceName = slot.AllyName;
                 }
-                newList.Add(new PlayerListItem { Button = allianceName, SortCategory = team * 2, AllyTeam = team, Height = 25 });
+                newList.Add(new PlayerListItem { Button = allianceName, SortCategory = team * 2 + (int)PlayerListItem.SortCats.Uncategorized, AllyTeam = team, Height = 25 });
             }
 
             //copy new startBox position, but keep old one and remove any extras

--- a/ZeroKLobby/MicroLobby/PlayerListItem.cs
+++ b/ZeroKLobby/MicroLobby/PlayerListItem.cs
@@ -13,6 +13,22 @@ namespace ZeroKLobby.MicroLobby
 {
     public class PlayerListItem: IDisposable
     {
+        /// <summary>
+        /// Important values used to make sure playerlist shows name in correct order during searching and/or in battleroom
+        /// </summary>
+        public enum SortCats
+        {
+            SearchTitle = 0,
+            SearchMatchedPlayer = 1,
+            SearchNoMatchTitle =2,
+            SearchNoMatchPlayer = 3,
+            //others
+            Uncategorized = 4,
+            QueueTitle = 5,
+            SpectatorTitle = 101,
+            Spectators = 102,
+        }
+
         //readonly Font boldFont = new Font("Microsoft Sans Serif", 9, FontStyle.Bold);
         readonly Font boldFont = new Font(Program.Conf.ChatFont.FontFamily, Program.Conf.ChatFont.Size - 2, FontStyle.Bold);
 
@@ -78,6 +94,7 @@ namespace ZeroKLobby.MicroLobby
         public PlayerListItem()
         {
             height = (int)font.Size*2;
+            SortCategory = (int)SortCats.Uncategorized;
         }
 
         ~PlayerListItem()
@@ -229,22 +246,25 @@ namespace ZeroKLobby.MicroLobby
 
         public override string ToString()
         {
+            if (SortCategory < (int)SortCats.Uncategorized)
+                return SortCategory.ToString("00000") + UserName??string.Empty; //for ChatControl's search-filter only
+
             var name = string.Empty;
             if (MissionSlot != null)
             {
-                SortCategory = MissionSlot.TeamID;
+                SortCategory = MissionSlot.TeamID + (int)PlayerListItem.SortCats.Uncategorized;
                 name = MissionSlot.TeamName;
             }
             else if (UserBattleStatus != null)
             {
                 name = UserBattleStatus.Name;
-                if (UserBattleStatus.IsSpectator) SortCategory = 101;
-                else SortCategory = UserBattleStatus.AllyNumber*2 + 1;
+                if (UserBattleStatus.IsSpectator) SortCategory = (int)PlayerListItem.SortCats.Spectators;
+                else SortCategory = UserBattleStatus.AllyNumber * 2 + 1 + (int)PlayerListItem.SortCats.Uncategorized;
             }
             else if (BotBattleStatus != null)
             {
                 name = BotBattleStatus.Name;
-                SortCategory = BotBattleStatus.AllyNumber*2 + 1;
+                SortCategory = BotBattleStatus.AllyNumber * 2 + 1 + (int)PlayerListItem.SortCats.Uncategorized;
             }
             else if (UserName != null) name = UserName;
             else if (Title != null) name = Title;


### PR DESCRIPTION
this fix https://github.com/ZeroK-RTS/Zero-K-Infrastructure/issues/570
and fix it showing wrong result if you search (eg: in ZK channel) while you are in battleroom.

The bug was:
the 1st bug is because it wasn't intended to update while you search, but I don't see any regression of any function or feature while it does, so I made it obey https://github.com/ZeroK-RTS/Zero-K-Infrastructure/issues/570 
Line https://github.com/ZeroK-RTS/Zero-K-Infrastructure/pull/576/files#diff-3bb36f6c9dda362536527e8b698c38d1R445 

also, 2nd bug is because the player's SortOrder is also effected by player's team (for battleRoom), so I made it detect this case and skip them while searching
Line https://github.com/ZeroK-RTS/Zero-K-Infrastructure/pull/576/files#diff-b5d6baab0eb4cbe29263bf07ee6a0a2cR250

additionally I made some magic value to be a global constant (code cleanup) so that its easy for dev to find using IDE
Line: https://github.com/ZeroK-RTS/Zero-K-Infrastructure/pull/576/files#diff-b5d6baab0eb4cbe29263bf07ee6a0a2cR16 