### PR TITLE
Package downloader anti spam tweak

### DIFF
--- a/Shared/PlasmaDownloader/Packages/PackageDownloader.cs
+++ b/Shared/PlasmaDownloader/Packages/PackageDownloader.cs
@@ -30,11 +30,10 @@ namespace PlasmaDownloader.Packages
 
     public class PackageDownloader : IDisposable
     {
-        bool isRefreshing;
-        bool refreshed;
+        public bool isRefreshing;
+        public bool refreshed;
         string masterContent;
-        DateTime LastRefresh;
-        readonly TimeSpan _3Second;
+        public DateTime LastRefresh;
         readonly string masterUrl;
         readonly PlasmaDownloader plasmaDownloader;
         readonly Timer refreshTimer;
@@ -53,9 +52,6 @@ namespace PlasmaDownloader.Packages
 
         public PackageDownloader(PlasmaDownloader plasmaDownloader)
         {
-            LastRefresh = DateTime.Now.Subtract(new TimeSpan(0, 0, 6));
-            _3Second = new TimeSpan(0, 0, 3);
-
             this.plasmaDownloader = plasmaDownloader;
             masterUrl = this.plasmaDownloader.Config.PackageMasterUrl;
             LoadRepositories();
@@ -158,13 +154,7 @@ namespace PlasmaDownloader.Packages
         {
             return Task.Factory.StartNew(() =>
             {
-                if (!refreshed && isRefreshing)
-                {
-                    do Thread.Sleep(500); while (isRefreshing); //keep caller waiting until we deliver a refreshed copy.
-                    return;
-                }
-                if (refreshed && isRefreshing) return;
-                if (refreshed && DateTime.Now.Subtract(LastRefresh) <= _3Second) return;
+                if (isRefreshing) return;
                 LastRefresh = DateTime.Now;
                 isRefreshing = true;
 

--- a/Shared/PlasmaShared/GlobalConst.cs
+++ b/Shared/PlasmaShared/GlobalConst.cs
@@ -123,7 +123,7 @@ namespace ZkData
         public const int CommanderProfileCount = 6;
         public const int NumCommanderLevels = 5;
 
-        public const string DefaultEngineOverride = "98.0.1-398-g80e6cfa"; // hack for ZKL using tasclient's engine - override here for missions etc
+        public const string DefaultEngineOverride = "98.0.1-451-g0804ae1"; // hack for ZKL using tasclient's engine - override here for missions etc
 
         public const int MinDurationForXP = 240;    // seconds
         public const int MinDurationForElo = 60;

--- a/ZeroKLobby/MicroLobby/DownloaderTab.cs
+++ b/ZeroKLobby/MicroLobby/DownloaderTab.cs
@@ -9,6 +9,8 @@ namespace ZeroKLobby.MapDownloader
 {
   public partial class DownloaderTab: UserControl, INavigatable
   {
+      Timer antiSpamTimer;
+
     public DownloaderTab()
     {
         Paint += DownloaderTab_Enter;
@@ -130,6 +132,19 @@ namespace ZeroKLobby.MapDownloader
     {
         manifestDownloading = true;
         Program.Downloader.PackageDownloader.LoadMasterAndVersions(true);
+
+        btnReload.Enabled = false;
+        antiSpamTimer = new Timer();
+        antiSpamTimer.Interval = 20*1000;
+        antiSpamTimer.Tick += antiSpamTimer_Tick;
+        antiSpamTimer.Start();
+    }
+
+    void antiSpamTimer_Tick(object sender, EventArgs e)
+    {
+        btnReload.Enabled = true;
+        antiSpamTimer.Stop();
+        antiSpamTimer.Dispose();
     }
 
     void lbInstalled_DoubleClick(object sender, EventArgs e)


### PR DESCRIPTION
I remove the recent 3 sec anti-spam code from PackageDownloader.cs. This is because IMO its the caller that must avoid spam.

so I added 2 minute anti-spam code to PlasmaDownloader.cs (which is the caller of the Refresh). This period is same to one used by ZKL before ( as mentioned here: https://github.com/ZeroK-RTS/Zero-K-Infrastructure/issues/558 )

Additional change is: 
  - default engine to Spring 98.0.1-451
  - add 20sec cooldown timer to Reload button in Rapid tab to avoid spam
