### PR TITLE
Raises !y votes needed for !voteresign to 67%

### DIFF
--- a/Springie/Springie/autohost/Polls/VoteResign.cs
+++ b/Springie/Springie/autohost/Polls/VoteResign.cs
@@ -18,7 +18,7 @@ namespace Springie.autohost.Polls
                 if (voteStarter != null)
                 {
                     question = string.Format("Resign team {0}?", voteStarter.AllyID + 1);
-                    winCount = context.Players.Count(x => x.AllyID == voteStarter.AllyID && !x.IsSpectator) * 0.6 + 1;
+                    winCount = context.Players.Count(x => x.AllyID == voteStarter.AllyID && !x.IsSpectator) * 2/3 + 1;
                     return true;
                 }
             }

--- a/Springie/Springie/autohost/Polls/VoteResign.cs
+++ b/Springie/Springie/autohost/Polls/VoteResign.cs
@@ -18,7 +18,7 @@ namespace Springie.autohost.Polls
                 if (voteStarter != null)
                 {
                     question = string.Format("Resign team {0}?", voteStarter.AllyID + 1);
-                    winCount = context.Players.Count(x => x.AllyID == voteStarter.AllyID && !x.IsSpectator) / 2 + 1;
+                    winCount = context.Players.Count(x => x.AllyID == voteStarter.AllyID && !x.IsSpectator) * 0.6 + 1;
                     return true;
                 }
             }


### PR DESCRIPTION
Because there are way too many thrown games with the current 50% requirement.

Note that it's actually 67%+1 rounded down (provided thats how c# works), or:
2 people in 2v2
3 people in 3v3 and 4v4
4 people in 5v5
5 people in 6v6 and 7v7
etc.

Another option would be removing the vote's force-resign altogether (but keep the vote, it can help with communication), or only force-resigning !y voters.