### PR TITLE
Voting patch

### DIFF
--- a/Springie/Springie/autohost/AutoHost.cs
+++ b/Springie/Springie/autohost/AutoHost.cs
@@ -258,19 +258,11 @@ namespace Springie.autohost
                                 return true; // ALL OK
                             }
                             else {
-                                if (e.Place == SayPlace.Battle && tas.MyBattle != null && tas.MyBattle.NonSpectatorCount == 1 &&
-                                    (!command.StartsWith("vote") && HasRights("vote" + command, e) &&
-                                        tas.MyBattle.Users.Values.Any(u => u.Name == e.UserName && !u.IsSpectator))) {
-                                    // server only has 1 player and we have rights for vote variant - we might as well just do it
-                                    return true;
-                                }
-                                else {
-                                    Respond(e,
-                                            String.Format("Sorry, you do not have rights to execute {0}{1}",
-                                                          command,
-                                                          (!string.IsNullOrEmpty(bossName) ? ", ask boss admin " + bossName : "")));
+                                Respond(e,
+                                    String.Format("Sorry, you do not have rights to execute {0}{1}",
+                                        command,
+                                        (!string.IsNullOrEmpty(bossName) ? ", ask boss admin " + bossName : "")));
                                     return false;
-                                }
                             }
                         }
                     }

--- a/Springie/Springie/autohost/Polls/AbstractPoll.cs
+++ b/Springie/Springie/autohost/Polls/AbstractPoll.cs
@@ -44,7 +44,13 @@ namespace Springie.autohost.Polls
                 if (WinCount <= 1 && tas.MyBattle.NonSpectatorCount != 0 &&
                         tas.MyBattle.Users.Values.All(u => u.Name != e.UserName || u.IsSpectator))
                     WinCount = 2;
-                ah.SayBattle(string.Format("Poll: {0} [!y=0/{1}, !n=0/{1}]", Question, WinCount));
+
+                if (WinCount == 1) {
+                    SuccessAction();
+                    return false;
+                } else if (!Vote(e, true)) {
+                    ah.SayBattle(string.Format("Poll: {0} [!y=0/{1}, !n=0/{1}]", Question, WinCount));
+                }
                 return true;
             }
             else return false;


### PR DESCRIPTION
* polls now start with !y vote from vote starter
* doing !command when not having rights for it but having rights for !votecommand will now run the vote variant, not the full variant (important because for example !move ignores room passwords, but !votemove doesnt).