### PR TITLE
Site user tooltip: don't show aliases

### DIFF
--- a/Zero-K.info/Views/Home/UserTooltip.cshtml
+++ b/Zero-K.info/Views/Home/UserTooltip.cshtml
@@ -43,8 +43,3 @@
     }
     <br class="clearfloat" />
 </div><br />
-
-
-@if (!string.IsNullOrEmpty(u.Aliases)) {
-    <b>Aliases: </b>@u.Aliases<br />
-}


### PR DESCRIPTION
* is problematic because it can take over half the screen in extreme cases (for example fireman)
* is no longer needed because you can't rename manually anymore