### PR TITLE
Keep player name after logout for convenience

### DIFF
--- a/ZeroKLobby/NavigationControl.cs
+++ b/ZeroKLobby/NavigationControl.cs
@@ -335,7 +335,6 @@ namespace ZeroKLobby
         private void logoutButton_Click(object sender, EventArgs e)
         {
             Program.TasClient.RequestDisconnect();
-            Program.Conf.LobbyPlayerName = "";
             Program.Conf.LobbyPlayerPassword = "";
         }
 


### PR DESCRIPTION
Do not discard user name immediately on logout. Discarding the password should be enough.