### PR TITLE
Changes !voteresign threshold to 3/5+1

### DIFF
--- a/Springie/Springie/autohost/Polls/VoteResign.cs
+++ b/Springie/Springie/autohost/Polls/VoteResign.cs
@@ -18,7 +18,7 @@ namespace Springie.autohost.Polls
                 if (voteStarter != null)
                 {
                     question = string.Format("Resign team {0}?", voteStarter.AllyID + 1);
-                    winCount = context.Players.Count(x => x.AllyID == voteStarter.AllyID && !x.IsSpectator) * 2/3 + 1;
+                    winCount = context.Players.Count(x => x.AllyID == voteStarter.AllyID && !x.IsSpectator) * 3/5 + 1;
                     return true;
                 }
             }


### PR DESCRIPTION
Used to be 1/2+1 a month ago, but people always resigned "for no reason" (meaning too soon, either "to troll" or out of frustration from their comm dying, etc.). Is currently 2/3+1, but people complain because afkers have to vote. With afkers having to vote really being a bit of an issue I suggest 3/5+1.

Ultimately leavers and afkers should not be needed to vote, but from what (little) I understand that requires either a redo of "spring.StartContext" or a new BattleContext object to return always-up-to-date data **to prevent abuse of the voting system**. I'm not up to this task right now. See this commit for a nice summary of the issue: https://github.com/ZeroK-RTS/Zero-K-Infrastructure/commit/c961d1e9a281e9e6cf892d13cdb69db7d8d99aa6

Here's a table showing the number of votes required for different thresholds.
![resign votes needed github version](https://cloud.githubusercontent.com/assets/132906/7563941/5790f7aa-f7e2-11e4-9df0-d81d44fb8c15.png)