### PR TITLE
make pw page not uber bad

### DIFF
--- a/Zero-K.info/Views/Planetwars/GalaxyOffline.cshtml
+++ b/Zero-K.info/Views/Planetwars/GalaxyOffline.cshtml
@@ -1,8 +1,7 @@
 ﻿@model ZkData.Galaxy
 
-<h2>Toasters are toast</h2>
-<img src="http://i.imgur.com/BdyfBSd.png" /><br/>
-<!-- http://i.imgur.com/0PAehPl.png -->
+<h2>Planet Wars are currently closed</h2>
+Planet Wars are currently closed. Recap of the last round:
 
 Humanity Rising swift attack took Hegemony by a fatal surprise. In what has been just a blink of an eye, forces of Rising completely eliminated Synthetic Hegemony, leaving no room for it to hide.<br/>
 <br/>


### PR DESCRIPTION
remove ultra-ugly poster and replace with info that PW is closed and that stuff on the page is recap of previous round