### PR TITLE
xponen's startbox shuffler part 1

### DIFF
--- a/Shared/LobbyClient/Battle.cs
+++ b/Shared/LobbyClient/Battle.cs
@@ -295,6 +295,18 @@ namespace LobbyClient
                 userNum++;
             }
 
+            //Shuffle startbox
+            if (_modOptions.ContainsKey("shuffledbox"))
+            {
+                List<KeyValuePair<int,BattleRect>> shuffled = _rectangles.Shuffle();
+                int cnt = 0;
+                foreach (var keyValue in _rectangles)
+                {
+                    _rectangles[keyValue.Key] = shuffled[cnt].Value;
+                    cnt++;
+                }
+            }
+
             // ALLIANCES AND START BOXES
             // var startboxes = new StringBuilder();
             // startboxes.AppendFormat("return { ");

--- a/Shared/LobbyClient/Battle.cs
+++ b/Shared/LobbyClient/Battle.cs
@@ -43,6 +43,7 @@ namespace LobbyClient
 
         public string Password;
 
+        public bool ShuffleBox { get; set; }
         public ConcurrentDictionary<int, BattleRect> Rectangles { get; set; }
         public string EngineName = "spring";
         public string EngineVersion { get; set; }
@@ -243,7 +244,7 @@ namespace LobbyClient
                     }
 
 
-                    GeneratePlayerSection(playersExport, users, script, bots, Rectangles, ModOptions, localUser, startSetup);
+                    GeneratePlayerSection(playersExport, users, script, bots, Rectangles, ModOptions, localUser, startSetup,ShuffleBox);
 
                     return script.ToString();
                 }
@@ -261,7 +262,8 @@ namespace LobbyClient
             IDictionary<int, BattleRect> _rectangles,
             Dictionary<string, string> _modOptions,
             User localUser = null,
-            SpringBattleStartSetup startSetup = null
+            SpringBattleStartSetup startSetup = null,
+            bool shuffleBox = false
            )
         {
             // ordinary battle stuff
@@ -296,7 +298,7 @@ namespace LobbyClient
             }
 
             //Shuffle startbox
-            if (_modOptions.ContainsKey("shuffledbox"))
+            if (shuffleBox)
             {
                 List<KeyValuePair<int,BattleRect>> shuffled = _rectangles.Shuffle();
                 int cnt = 0;
@@ -345,6 +347,9 @@ namespace LobbyClient
                 // write final options to script
                 foreach (var kvp in options) script.AppendFormat("    {0}={1};\n", kvp.Key, kvp.Value);
 
+                // signal to game if we shuffled the box (optional)
+                if (shuffleBox) script.AppendLine("    shuffledbox=1;\n");
+                
                 script.AppendLine("  }");
 
 

--- a/Springie/Springie/Springie.csproj
+++ b/Springie/Springie/Springie.csproj
@@ -118,6 +118,7 @@
     <Compile Include="autohost\CommandList.cs" />
     <Compile Include="autohost\MatchMakerQueue.cs" />
     <Compile Include="autohost\Polls\AbstractPoll.cs" />
+    <Compile Include="autohost\Polls\VoteShuffleBox.cs" />
     <Compile Include="autohost\Polls\VotePlanet.cs" />
     <Compile Include="autohost\Polls\VoteResetOptions.cs" />
     <Compile Include="autohost\Polls\VoteMove.cs" />

--- a/Springie/Springie/autohost/AutoHost.cs
+++ b/Springie/Springie/autohost/AutoHost.cs
@@ -335,16 +335,12 @@ namespace Springie.autohost
 
                     break;
 
-                case "startshuffled":
-                    tas.UpdateModOptions(new Dictionary<string, string>() 
-                        {{ "shuffledbox", "1" }}
-                    );
-                    if (tas.MyBattle != null)
-                    {
-                        int cnt = tas.MyBattle.NonSpectatorCount;
-                        if (cnt == 1) ComStart(e, words);
-                        else StartVote(new VoteStart(tas, spring, this), e, words);
-                    }
+                case "shufflebox":
+                    ComShuffleBox(e, words);
+                    break;
+
+                case "voteshufflebox":
+                    StartVote(new VoteShuffleBox(tas, spring, this), e, words);
                     break;
 
                 case "forcestart":

--- a/Springie/Springie/autohost/AutoHost.cs
+++ b/Springie/Springie/autohost/AutoHost.cs
@@ -335,6 +335,18 @@ namespace Springie.autohost
 
                     break;
 
+                case "startshuffled":
+                    tas.UpdateModOptions(new Dictionary<string, string>() 
+                        {{ "shuffledbox", "1" }}
+                    );
+                    if (tas.MyBattle != null)
+                    {
+                        int cnt = tas.MyBattle.NonSpectatorCount;
+                        if (cnt == 1) ComStart(e, words);
+                        else StartVote(new VoteStart(tas, spring, this), e, words);
+                    }
+                    break;
+
                 case "forcestart":
                     ComForceStart(e, words);
                     break;

--- a/Springie/Springie/autohost/AutoHost_commands.cs
+++ b/Springie/Springie/autohost/AutoHost_commands.cs
@@ -424,6 +424,21 @@ namespace Springie.autohost
             }
         }
 
+        public void ComShuffleBox(TasSayEventArgs e, string[] words)
+        {
+            if (tas.MyBattle == null) return;
+
+            int x;
+            if (words.Length != 1 || !Int32.TryParse(words[0], out x))
+            {
+                Respond(e, "You must specify 1 or 0 as parameter");
+                return;
+            }
+
+            tas.MyBattle.ShuffleBox = (x>0);
+            Respond(e, (x > 0)?"Startbox shuffling is active":"Startbox shuffling is off");
+            return;
+        }
 
         public void ComExit(TasSayEventArgs e, string[] words)
         {

--- a/Springie/Springie/autohost/CommandList.cs
+++ b/Springie/Springie/autohost/CommandList.cs
@@ -25,6 +25,11 @@ namespace Springie.autohost
 
             AddMissing(new CommandConfig("start", 1, " - starts game", 5));
 
+            AddMissing(new CommandConfig("startshuffled",
+                                         1,
+                                         "- similar to start, but shuffle the startboxes and add flag \"shuffledbox=1\" to modoptions",
+                                         5));
+
             AddMissing(new CommandConfig("ring",
                                          1,
                                          "[<filters>..] - rings all unready or specific player(s), e.g. !ring - rings unready, !ring icho - rings Licho",

--- a/Springie/Springie/autohost/CommandList.cs
+++ b/Springie/Springie/autohost/CommandList.cs
@@ -25,9 +25,14 @@ namespace Springie.autohost
 
             AddMissing(new CommandConfig("start", 1, " - starts game", 5));
 
-            AddMissing(new CommandConfig("startshuffled",
+            AddMissing(new CommandConfig("shufflebox",
+                                         2,
+                                         "<1|0> - shuffle alliance startbox at start of game and add a flag \"shuffledbox=1|0\" to modoptions",
+                                         5));
+
+            AddMissing(new CommandConfig("voteshufflebox",
                                          1,
-                                         "- similar to start, but shuffle the startboxes and add flag \"shuffledbox=1\" to modoptions",
+                                         "<1|0> - start a vote to shuffle box",
                                          5));
 
             AddMissing(new CommandConfig("ring",

--- a/Springie/Springie/autohost/Polls/VoteShuffleBox.cs
+++ b/Springie/Springie/autohost/Polls/VoteShuffleBox.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Threading;
+using LobbyClient;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Springie.autohost.Polls
+{
+    public class VoteShuffleBox : AbstractPoll
+    {
+        bool shuffleBox;
+
+        public VoteShuffleBox(TasClient tas, Spring spring, AutoHost ah) : base(tas, spring, ah) { }
+
+        protected override bool PerformInit(TasSayEventArgs e, string[] words, out string question, out int winCount)
+        {
+            winCount = 0;
+            question = null;
+
+            if (tas.MyBattle == null) return false;
+
+            if (spring.IsRunning)
+            {
+                AutoHost.Respond(tas, spring, e, "Cannot set options while the game is running");
+                return false;
+            }
+            int x;
+            if (words.Length != 1 || !Int32.TryParse(words[0], out x))
+            {
+                AutoHost.Respond(tas, spring, e, "Parameters must be a 1 or 0");
+                return false;
+            }
+            //Already voted for?
+            if (x > 0 && tas.MyBattle.ShuffleBox)
+            {
+                AutoHost.Respond(tas, spring, e, "Startbox shuffling already active.");
+                return false;
+            }
+            else if (x <= 0 && !tas.MyBattle.ShuffleBox)
+            {
+                AutoHost.Respond(tas, spring, e, "Startbox shuffling already off.");
+                return false;
+            }
+
+            question = (x > 0)?"Activate startbox shuffling":"Deactivate startbox shuffling";
+            shuffleBox = (x > 0);
+            return true;
+        }
+
+        protected override void SuccessAction()
+        {
+            ah.ComShuffleBox(TasSayEventArgs.Default, new string[] { shuffleBox?"1":"0" });
+        }
+    }
+}


### PR DESCRIPTION
added (to Springie) a cousin of !start: !startshuffled which invisibly shuffle player's startbox, then start the game.

Is very lightweight and very easy to understand. Completely independent of games, shouldn't cause much issue.

Related: https://github.com/ZeroK-RTS/Zero-K/issues/544