### PR TITLE
Revert "Startbox patch"

### DIFF
--- a/Shared/LobbyClient/Battle.cs
+++ b/Shared/LobbyClient/Battle.cs
@@ -296,33 +296,34 @@ namespace LobbyClient
             }
 
             // ALLIANCES AND START BOXES
-            var startboxes = new StringBuilder();
-            startboxes.Append("return { ");
+            // var startboxes = new StringBuilder();
+            // startboxes.AppendFormat("return { ");
             script.AppendLine();
-            for (int allyNumber = 1; allyNumber <= Spring.MaxAllies; allyNumber++)
+            foreach (var allyNumber in
+                users.Where(x => !x.IsSpectator).Select(x => x.AllyNumber).Union(bots.Select(x => x.AllyNumber)).Union(_rectangles.Keys).Distinct())
             {
+                // get allies from each player, bot and rectangles (for koth)
                 script.AppendFormat("[ALLYTEAM{0}]\n", allyNumber);
                 script.AppendLine("{");
-                script.AppendLine("     NumAllies=0;");
+                script.AppendFormat("     NumAllies={0};\n", 0);
+                double left = 0, top = 0, right = 1, bottom = 1;
                 BattleRect rect;
-                if (_rectangles.TryGetValue(allyNumber, out rect)) {
-                    double left = 0, top = 0, right = 1, bottom = 1;
-                    rect.ToFractions(out left, out top, out right, out bottom);
-                    startboxes.AppendFormat(CultureInfo.InvariantCulture, "[{0}] = ", allyNumber);
-                    startboxes.Append("{ ");
-                    startboxes.AppendFormat(CultureInfo.InvariantCulture, "{0}, {1}, {2}, {3}", left, top, right, bottom);
-                    startboxes.Append(" }, ");
-                }
+                if (_rectangles.TryGetValue(allyNumber, out rect)) rect.ToFractions(out left, out top, out right, out bottom);
+                script.AppendFormat(CultureInfo.InvariantCulture, "     StartRectLeft={0};\n", left);
+                script.AppendFormat(CultureInfo.InvariantCulture, "     StartRectTop={0};\n", top);
+                script.AppendFormat(CultureInfo.InvariantCulture, "     StartRectRight={0};\n", right);
+                script.AppendFormat(CultureInfo.InvariantCulture, "     StartRectBottom={0};\n", bottom);
+                // startboxes.AppendFormat(CultureInfo.InvariantCulture, "[{0}] = { {1}, {2}, {3}, {4} }, ", allyNumber, left, top, right, bottom);
                 script.AppendLine("}");
             }
 
-            startboxes.Append("}");
+            // startboxes.AppendFormat("}");
             script.AppendLine();
 
                 script.AppendLine("  [MODOPTIONS]");
                 script.AppendLine("  {");
 
-                script.AppendFormat("    startboxes={0};\n", startboxes.ToString());
+                // script.AppendFormat("    startboxes={0};\n", startboxes.ToString());
 
                 var options = new Dictionary<string, string>(_modOptions);
 


### PR DESCRIPTION
Reverts ZeroK-RTS/Zero-K-Infrastructure#641
this break Local game Skirmisher's compatibility with other games, and break server compatibility with other games.

The reason is simple, @Sprunk don't want engine startbox because it conflict with his LUA reimplementation of startbox.

This is bad, because startbox already work fine. If you want to shuffle it, just shuffle the content of startscript, not this.