### PR TITLE
Fix crash

### DIFF
--- a/Shared/LobbyClient/Battle.cs
+++ b/Shared/LobbyClient/Battle.cs
@@ -299,7 +299,7 @@ namespace LobbyClient
             var startboxes = new StringBuilder();
             startboxes.Append("return { ");
             script.AppendLine();
-            for (int allyNumber = 1; allyNumber <= Spring.MaxAllies; allyNumber++)
+            for (int allyNumber = 0; allyNumber < Spring.MaxAllies; allyNumber++)
             {
                 script.AppendFormat("[ALLYTEAM{0}]\n", allyNumber);
                 script.AppendLine("{");


### PR DESCRIPTION
Note: since it was not Springie then some other part of the infra still has 1-based boxes (perhaps the super obscure skirmish).