### PR TITLE
More appropriate !votemove poll title.

### DIFF
--- a/Springie/Springie/autohost/Polls/VoteMove.cs
+++ b/Springie/Springie/autohost/Polls/VoteMove.cs
@@ -38,7 +38,7 @@ namespace Springie.autohost.Polls
                 return false;
             }
 
-            question = string.Format("Move all to {0}?", host);
+            question = string.Format("Do you want to join {0}?", host);
             return true;
 
         }


### PR DESCRIPTION
Old title suggests all players get moved on successful vote which is confusing to some players.