### PR TITLE
Revert "Springie: autobalance in custom rooms"

### DIFF
--- a/Springie/Springie/autohost/AutoHost_commands.cs
+++ b/Springie/Springie/autohost/AutoHost_commands.cs
@@ -832,20 +832,34 @@ namespace Springie.autohost
             List<string> usname;
             if (!AllReadyAndSynced(out usname))
             {
-                SayBattle("Cannot start, " + Utils.Glue(usname.ToArray()) + " does not have the map/game yet");
+                SayBattle("cannot start, " + Utils.Glue(usname.ToArray()) + " does not have the map/game yet");
                 return;
             }
 
-            if (SpawnConfig == null && config != null && config.Mode != AutohostMode.None)
+            if (SpawnConfig != null)
             {
-                if (!RunServerBalance(true, null, null))
+                int allyno;
+                int alliances;
+                if (!BalancedTeams(out allyno, out alliances))
                 {
-                    SayBattle("Cannot start a game at the moment.");
+                    SayBattle("cannot start, alliance " + (allyno + 1) + " not fair. Use !forcestart to override");
                     return;
                 }
             }
+            else
+            {
+                if (config != null && config.Mode != AutohostMode.None)
+                {
+                    if (!RunServerBalance(true, null, null))
+                    {
+                        SayBattle("Cannot start a game atm");
+                        return;
+                    }
 
-            SayBattle("Please wait, game is about to start.");
+                }
+            }
+
+            SayBattle("please wait, game is about to start");
             StopVote();
             lastSplitPlayersCountCalled = 0;
             tas.StartGame();


### PR DESCRIPTION
Reverts ZeroK-RTS/Zero-K-Infrastructure#704
To apply this it should also happen in spring class where it contacts server for final balance.

But I don't think it's good idea, custom rooms are mainly for newbies. They don't know about force start.
Game should not do such things automagically, it should be explicity (balance button in lobby for example)