### PR TITLE
wait 20 seconds before hardkilling spring; see #743

### DIFF
--- a/Shared/LobbyClient/Spring.cs
+++ b/Shared/LobbyClient/Spring.cs
@@ -154,7 +154,7 @@ namespace LobbyClient
             try {
                 if (IsRunning) {
                     SayGame("/kill"); // todo dont do this if talker does not work (not a host)
-                    process.WaitForExit(5000);
+                    process.WaitForExit(20000);
                     if (!IsRunning) return;
                     
                     Console.WriteLine("Terminating Spring process due to /kill timeout");


### PR DESCRIPTION
There are quite many unsaved replays, and quite many hardkill reports in springie log.
This is to see if 20s is enough for spring to quit. If it's not, going to check for dedicated hang ... somehow.