### PR TITLE
Fix replays index page

### DIFF
--- a/Zero-K.info/Views/Battles/Index.cshtml
+++ b/Zero-K.info/Views/Battles/Index.cshtml
@@ -13,8 +13,8 @@
   @Html.TextBox("mod", "Zero-K")
   <br />
   Player Involved:
-  @*@Html.TextBox("user")*@
-  @Html.TextBox("user", Global.IsAccountAuthorized ? Global.Account.Name : "")
+  @Html.TextBox("user")
+  @*Html.TextBox("user", Global.IsAccountAuthorized ? Global.Account.Name : "")*@
   # of Players:
   @Html.TextBox("players")
   <br />

--- a/Zero-K.info/Views/Shared/UserDetail.cshtml
+++ b/Zero-K.info/Views/Shared/UserDetail.cshtml
@@ -251,7 +251,7 @@
 	    
         if (Model.SpringBattlePlayers.Any()) {
             <div id="usr_recentbattles" class="fleft border">
-                <h3>@Html.ActionLink("Last battles", "Index", "Battles")</h3>
+                <h3>@Html.ActionLink("Last battles", "Index", "Battles", new {user = Model.Name}, null)</h3>
                 <span>
                     @Model.SpringBattlePlayers.Count(x => !x.IsSpectator) played, @Model.SpringBattlePlayers.Count(x => x.IsSpectator)
                     watched, @Model.MissionRunCount missions 


### PR DESCRIPTION
* Don't display user's name by default since it is not actually filtering by user name
* When following the user page's "last battles" links, do use the appropriate user name

Fixes #751