### PR TITLE
Zip handling patch

### DIFF
--- a/MissionEditor/CMissionLib/CMissionLib.csproj
+++ b/MissionEditor/CMissionLib/CMissionLib.csproj
@@ -49,6 +49,8 @@
     <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
@@ -208,6 +210,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/MissionEditor/CMissionLib/Mission.cs
+++ b/MissionEditor/CMissionLib/Mission.cs
@@ -13,7 +13,6 @@ using System.Xml;
 using System.Xml.Serialization;
 using CMissionLib.Actions;
 using CMissionLib.Conditions;
-using Ionic.Zip;
 using Microsoft.SqlServer.Server;
 using MissionEditor2;
 using ZkData.UnitSyncLib;
@@ -21,6 +20,7 @@ using CMissionLib.UnitSyncLib;
 using ZkData;
 using Map = CMissionLib.UnitSyncLib.Map;
 using Mod = CMissionLib.UnitSyncLib.Mod;
+using System.IO.Compression;
 
 namespace CMissionLib
 {
@@ -324,8 +324,13 @@ namespace CMissionLib
 				File.WriteAllText("modinfo.txt", modInfo);
 				//File.WriteAllText("mission.lua", luaMissionData);
 			}
-			var textEncoding = Encoding.GetEncoding("iso-8859-1"); // ASCIIEncoding()
-			using (var zip = new ZipFile())
+			var textEncoding = Encoding.UTF8; // ASCIIEncoding()
+			
+			string directory = Path.GetDirectoryName(mutatorPath);
+			if (!Directory.Exists(directory)) Directory.CreateDirectory(directory);
+			if (File.Exists(mutatorPath)) File.Delete(mutatorPath);
+			
+			using (var zip = ZipFile.Open(mutatorPath, ZipArchiveMode.Update, Encoding.UTF8))
 			{
 				if (!String.IsNullOrEmpty(ContentFolderPath) && Directory.Exists(ContentFolderPath)) zip.SafeAddDirectory(ContentFolderPath);
 
@@ -333,11 +338,11 @@ namespace CMissionLib
 				var basePath = Path.Combine(assemblyLocation, "MissionBase");
 				zip.SafeAddDirectory(basePath);
 
-				zip.SafeAddEntry("modinfo.lua", textEncoding.GetBytes(modInfo));
-				zip.SafeAddEntry("mission.lua", textEncoding.GetBytes(luaMissionData));
-				zip.SafeAddEntry("script.txt", textEncoding.GetBytes(script));
-				zip.SafeAddEntry(GlobalConst.MissionScriptFileName, textEncoding.GetBytes(script));
-				zip.SafeAddEntry("slots.lua", textEncoding.GetBytes(GetLuaSlots().ToString()));
+				zip.SafeAddEntry("modinfo.lua", modInfo);
+				zip.SafeAddEntry("mission.lua", luaMissionData);
+				zip.SafeAddEntry("script.txt", script);
+				zip.SafeAddEntry(GlobalConst.MissionScriptFileName, script);
+				zip.SafeAddEntry("slots.lua", GetLuaSlots().ToString());
 				zip.SafeAddEntry("dependencies.txt", String.Join(";", Mod.Dependencies)); // FIXME
 
 				{
@@ -356,7 +361,7 @@ namespace CMissionLib
 				}
 
 				// disable scripts by hiding them with a blank file
-				var blank = textEncoding.GetBytes("-- intentionally left blank --");
+				var blank = "-- intentionally left blank --";
 				foreach (var widget in disabledWidgets.Distinct()) zip.SafeAddEntry("LuaUI/Widgets/" + widget, blank);
 				foreach (var gadget in disabledGadgets.Distinct()) zip.SafeAddEntry("LuaRules/Gadgets/" + gadget, blank);
 
@@ -421,10 +426,6 @@ namespace CMissionLib
                         }
                     }
 				}
-                string directory = Path.GetDirectoryName(mutatorPath);
-                if (!Directory.Exists(directory)) Directory.CreateDirectory(directory);
-
-				zip.Save(mutatorPath);
 			}
 		}
 
@@ -439,15 +440,10 @@ namespace CMissionLib
 			else
 			{
 				var projectFileName = "project.mission.xml";
-				using (var zip = ZipFile.Read(path))
+				using (var zip = ZipFile.OpenRead(path))
 				{
-					var entry = zip.First(e => e.FileName == projectFileName);
-					using (var memoryStream = new MemoryStream())
-					{
-						entry.Extract(memoryStream);
-						memoryStream.Position = 0;
-						return (Mission)new NetDataContractSerializer().ReadObject(memoryStream);
-					}
+					var entry = zip.Entries.First(e => Path.GetFileName(e.Name) == projectFileName);
+					return (Mission)new NetDataContractSerializer().ReadObject(entry.Open());
 				}
 			}
 		}

--- a/Shared/PlasmaDownloader/PlasmaDownloader.csproj
+++ b/Shared/PlasmaDownloader/PlasmaDownloader.csproj
@@ -78,9 +78,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="SharpCompress, Version=0.9.0.0, Culture=neutral, PublicKeyToken=beaf6f427e128133, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\sharpcompress.0.9\lib\net40\SharpCompress.dll</HintPath>
+    <Reference Include="SharpCompress, Version=0.10.3.0, Culture=neutral, PublicKeyToken=beaf6f427e128133, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\sharpcompress.0.11.1\lib\net40\SharpCompress.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net" />

--- a/Shared/PlasmaDownloader/packages.config
+++ b/Shared/PlasmaDownloader/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net451" />
-  <package id="sharpcompress" version="0.9" targetFramework="net451" />
+  <package id="sharpcompress" version="0.11.1" targetFramework="net451" />
 </packages>

--- a/Shared/PlasmaShared/PlasmaShared.csproj
+++ b/Shared/PlasmaShared/PlasmaShared.csproj
@@ -152,9 +152,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="SharpCompress, Version=0.9.0.0, Culture=neutral, PublicKeyToken=beaf6f427e128133, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\sharpcompress.0.9\lib\net40\SharpCompress.dll</HintPath>
+    <Reference Include="SharpCompress, Version=0.10.3.0, Culture=neutral, PublicKeyToken=beaf6f427e128133, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\sharpcompress.0.11.1\lib\net40\SharpCompress.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Shared/PlasmaShared/PlasmaShared.csproj
+++ b/Shared/PlasmaShared/PlasmaShared.csproj
@@ -148,9 +148,6 @@
     <Compile Include="Whois.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Ionic.Zip">
-      <HintPath>..\..\packages\DotNetZip.1.9.1.8\lib\net20\Ionic.Zip.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Shared/PlasmaShared/packages.config
+++ b/Shared/PlasmaShared/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.9.1.8" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net451" />
   <package id="sharpcompress" version="0.9" targetFramework="net451" />
   <package id="WebSocket4Net" version="0.12" targetFramework="net451" />

--- a/Shared/PlasmaShared/packages.config
+++ b/Shared/PlasmaShared/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net451" />
-  <package id="sharpcompress" version="0.9" targetFramework="net451" />
+  <package id="sharpcompress" version="0.11.1" targetFramework="net451" />
   <package id="WebSocket4Net" version="0.12" targetFramework="net451" />
 </packages>

--- a/Tests/SharpCompressTests.cs
+++ b/Tests/SharpCompressTests.cs
@@ -18,7 +18,7 @@ namespace Tests
         public void TestModifyZip() {
 
             var zf = ZipArchive.Open(new MemoryStream(File.ReadAllBytes(@"c:\temp\bench.zip")));
-            var entry = zf.Entries.First(x => x.FilePath == "poznamka.txt");
+            var entry = zf.Entries.First(x => x.Key == "poznamka.txt");
             var stream = entry.OpenEntryStream();
             var text = new StreamReader(stream).ReadToEnd();
             text = text + " haf haf";

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -47,8 +47,9 @@
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="SharpCompress">
-      <HintPath>..\packages\sharpcompress.0.9\lib\net40\SharpCompress.dll</HintPath>
+    <Reference Include="SharpCompress, Version=0.10.3.0, Culture=neutral, PublicKeyToken=beaf6f427e128133, processorArchitecture=MSIL">
+      <HintPath>..\packages\sharpcompress.0.11.1\lib\net40\SharpCompress.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="EntityFramework" version="6.1.2" targetFramework="net451" />
   <package id="NUnit" version="2.6.2" targetFramework="net451" />
-  <package id="sharpcompress" version="0.9" targetFramework="net451" />
+  <package id="sharpcompress" version="0.11.1" targetFramework="net451" />
 </packages>

--- a/ZkData/MissionService/MissionUpdater.cs
+++ b/ZkData/MissionService/MissionUpdater.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using Ionic.Zip;
+using System.IO.Compression;
 using MonoTorrent.Common;
 using ZkData.UnitSyncLib;
 
@@ -33,21 +33,29 @@ namespace ZkData
             sb.AppendLine("return modinfo");
             return sb.ToString();
         }
+
+        static void WriteZipArchiveEntry(ZipArchiveEntry entry, byte[] toWrite)
+        {
+            using (StreamWriter writer = new StreamWriter(entry.Open()))
+            {
+                writer.Write(toWrite);
+            }
+        }
   
         public void UpdateMission(ZkDataContext db, Mission mission, Mod modInfo) {
             var file = mission.Mutator.ToArray();
             var tempName = Path.GetTempFileName() + ".zip";
             File.WriteAllBytes(tempName, file);
 
-            using (var zf = new ZipFile(tempName))
+            using (var zf = ZipFile.Open(tempName, ZipArchiveMode.Update))
             {
-                zf.UpdateEntry("modinfo.lua", Encoding.UTF8.GetBytes(GetModInfo(mission.NameWithVersion, mission.Mod, mission.Name, "ZK")));    // FIXME hardcoded crap
+                var modinfoEntry = zf.CreateEntry("modinfo.lua");
+                WriteZipArchiveEntry(modinfoEntry, Encoding.UTF8.GetBytes(GetModInfo(mission.NameWithVersion, mission.Mod, mission.Name, "ZK")));
                 FixScript(mission, zf, "script.txt");
                 var script = FixScript(mission, zf, GlobalConst.MissionScriptFileName);
                 modInfo.MissionScript = script;
                 //modInfo.ShortName = mission.Name;
                 modInfo.Name = mission.NameWithVersion;
-                zf.Save();
             }
             mission.Mutator = File.ReadAllBytes(tempName);
             mission.Script = Regex.Replace(mission.Script, "GameType=([^;]+);", (m) => { return string.Format("GameType={0};", mission.NameWithVersion); });
@@ -106,13 +114,13 @@ namespace ZkData
             File.WriteAllBytes(string.Format(imgPath + "{0}.png", mission.MissionID, basePath), mission.Image.ToArray());
         }
 
-        static string FixScript(Mission mission, ZipFile zf, string scriptName)
+        static string FixScript(Mission mission, ZipArchive archive, string scriptName)
         {
-            var ms = new MemoryStream();
-            zf[scriptName].Extract(ms);
-            var script = Encoding.UTF8.GetString(ms.ToArray());
+            ZipArchiveEntry entry = archive.GetEntry(scriptName);
+            StreamReader reader = new StreamReader(entry.Open());
+            var script = Encoding.UTF8.GetString(Encoding.Default.GetBytes(reader.ReadToEnd()));
             script = Regex.Replace(script, "GameType=([^;]+);", (m) => { return string.Format("GameType={0};", mission.NameWithVersion); });
-            zf.UpdateEntry(scriptName, Encoding.UTF8.GetBytes(script));
+            WriteZipArchiveEntry(entry, Encoding.UTF8.GetBytes(script));
             return script;
         }
     }

--- a/ZkData/ZkData.csproj
+++ b/ZkData/ZkData.csproj
@@ -65,6 +65,8 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
* Remove DotNetZip (incompatible MS-PL license); use System.IO.Compression built into .NET 4.5 instead (#257)
* Update SharpCompress 0.9.0 to 0.11.1