### PR TITLE
"Report this player" -> "Contact admins" when reporting self

### DIFF
--- a/Zero-K.info/Views/Shared/UserDetail.cshtml
+++ b/Zero-K.info/Views/Shared/UserDetail.cshtml
@@ -99,7 +99,13 @@
                 </div>
             }
             <p class="fright" align="right">
-                <a href="@Url.Action("ReportToAdmin", "Users", new { id = Model.AccountID })" nicetitle="Report abuse to administrators">Report this player<img src="/img/abuse.png" height="32"/></a>
+            	@if (Model.AccountID == Global.AccountID) {
+            		<a href="@Url.Action("ReportToAdmin", "Users", new { id = Model.AccountID })" nicetitle="Report problems or abuse to administrators">Contact administrators<img src="/img/abuse.png" height="32"/></a>
+            	}
+            	else
+            	{
+            		<a href="@Url.Action("ReportToAdmin", "Users", new { id = Model.AccountID })" nicetitle="Report abuse to administrators">Report this player<img src="/img/abuse.png" height="32"/></a>
+            	}
                 <br/>
                 <a href="/Wiki/CodeOfConduct" nicetitle="Code of Conduct"><b><img src="/img/conduct.png" height="32"/></b></a>
             </p>


### PR DESCRIPTION
This commit is UNTESTED. I just randomly copied code without knowing C#, but expect this to work.

With this change users should see a "Contact administrators" button instead of the current "Report this player" button on their own profile page. That allows players to contact admins without "reporting" themselves. Note that this commit does not change the actual text that admins see in #zkadmin.

Reason for this commit:
#zkdev
[19:30]  Rafal[ZK] i think the "Report this player" button should change to "Contact moderators" when viewing own user page
[19:30]  Rafal[ZK] see #zkadmin why