### PR TITLE
Allow specs to vote on votesplitplayers and votemove

### DIFF
--- a/Springie/Springie/autohost/CommandList.cs
+++ b/Springie/Springie/autohost/CommandList.cs
@@ -120,17 +120,17 @@ namespace Springie.autohost
                                          0,
                                          "<number> - votes for given option (works from battle only), e.g. !vote 1",
                                          0,
-                                         new[] { SayPlace.Battle, SayPlace.Game }));
+                                         new[] { SayPlace.Battle, SayPlace.Game }) { AllowSpecs = true});
             AddMissing(new CommandConfig("y",
                                          0,
                                          "- votes for given option 1 (works from battle only), e.g. !y; !vote 1",
                                          0,
-                                         new[] { SayPlace.Battle, SayPlace.Game }));
+                                         new[] { SayPlace.Battle, SayPlace.Game }) { AllowSpecs = true});
             AddMissing(new CommandConfig("n",
                                          0,
                                          "- votes for given option 2 (works from battle only), e.g. !n; !vote 2",
                                          0,
-                                         new[] { SayPlace.Battle, SayPlace.Game }));
+                                         new[] { SayPlace.Battle, SayPlace.Game }) { AllowSpecs = true});
 
             AddMissing(new CommandConfig("rehost", 3, "[<modname>..] - rehosts game, e.g. !rehost abosol 2.23 - rehosts AA2.23"));
 

--- a/Springie/Springie/autohost/Polls/VoteKick.cs
+++ b/Springie/Springie/autohost/Polls/VoteKick.cs
@@ -48,5 +48,16 @@ namespace Springie.autohost.Polls
             ah.ComKick(TasSayEventArgs.Default, new[] { player });
         }
 
+        protected override bool AllowVote(TasSayEventArgs e)
+        {
+            if (tas.MyBattle == null) return false;
+            var entry = tas.MyBattle.Users.Values.FirstOrDefault(x => x.Name == e.UserName);
+            if (entry == null || entry.IsSpectator)
+            {
+                ah.Respond(e, string.Format("Only players can vote"));
+                return false;
+            }
+            else return true;
+        }
     }
 }

--- a/Springie/Springie/autohost/Polls/VoteMap.cs
+++ b/Springie/Springie/autohost/Polls/VoteMap.cs
@@ -112,5 +112,17 @@ namespace Springie.autohost.Polls
                 ah.ComMap(TasSayEventArgs.Default, new string[] { map });
             }
         }
+
+         protected override bool AllowVote(TasSayEventArgs e)
+        {
+            if (tas.MyBattle == null) return false;
+            var entry = tas.MyBattle.Users.Values.FirstOrDefault(x => x.Name == e.UserName);
+            if (entry == null || entry.IsSpectator)
+            {
+                ah.Respond(e, string.Format("Only players can vote"));
+                return false;
+            }
+            else return true;
+        }
     }
 }

--- a/Springie/Springie/autohost/Polls/VoteSetOptions.cs
+++ b/Springie/Springie/autohost/Polls/VoteSetOptions.cs
@@ -38,5 +38,17 @@ namespace Springie.autohost.Polls
         protected override void SuccessAction() {
             tas.UpdateModOptions(scriptTagsFormat);
         }
+
+        protected override bool AllowVote(TasSayEventArgs e)
+        {
+            if (tas.MyBattle == null) return false;
+            var entry = tas.MyBattle.Users.Values.FirstOrDefault(x => x.Name == e.UserName);
+            if (entry == null || entry.IsSpectator)
+            {
+                ah.Respond(e, string.Format("Only players can vote"));
+                return false;
+            }
+            else return true;
+        }
     }
 }

--- a/Springie/Springie/autohost/Polls/VoteSpec.cs
+++ b/Springie/Springie/autohost/Polls/VoteSpec.cs
@@ -35,5 +35,17 @@ namespace Springie.autohost.Polls
         protected override void SuccessAction() {
             ah.ComForceSpectator(TasSayEventArgs.Default, new[] { player });
         }
+
+         protected override bool AllowVote(TasSayEventArgs e)
+        {
+            if (tas.MyBattle == null) return false;
+            var entry = tas.MyBattle.Users.Values.FirstOrDefault(x => x.Name == e.UserName);
+            if (entry == null || entry.IsSpectator)
+            {
+                ah.Respond(e, string.Format("Only players can vote"));
+                return false;
+            }
+            else return true;
+        }
     }
 }

--- a/Springie/Springie/autohost/Polls/VoteSplitPlayers.cs
+++ b/Springie/Springie/autohost/Polls/VoteSplitPlayers.cs
@@ -27,13 +27,7 @@ namespace Springie.autohost.Polls
         protected override bool AllowVote(TasSayEventArgs e)
         {
             if (tas.MyBattle == null) return false;
-            var entry = tas.MyBattle.Users.Values.FirstOrDefault(x => x.Name == e.UserName);
-            if (entry == null || entry.IsSpectator)
-            {
-                ah.Respond(e, string.Format("Only players can vote"));
-                return false;
-            }
-            else return true;
+            return true;
         }
 
 


### PR DESCRIPTION
Also gives specs a response "only players can vote" if they try to vote on things they can't vote for (like kicks, map etc)