### PR TITLE
Map page: don't show useless info

### DIFF
--- a/Zero-K.info/Views/Maps/Detail.cshtml
+++ b/Zero-K.info/Views/Maps/Detail.cshtml
@@ -70,26 +70,6 @@
             <tr>
                 <td>Size: </td><td>@m.MapWidth x @m.MapHeight</td>
             </tr>
-            <tr>
-                <td>Wind:</td>
-                <td>@mi.MinWind - @mi.MaxWind</td>
-            </tr>
-            <tr>
-                <td>Metal:</td>
-                <td>@mi.MaxMetal</td>
-            </tr>
-            <tr>
-                <td>Tidal:</td>
-                <td>@mi.TidalStrength</td>
-            </tr>
-            <tr>
-                <td>Gravity:</td>
-                <td>@mi.Gravity</td>
-            </tr>
-            <tr>
-                <td>Extractor radius:</td>
-                <td>@mi.ExtractorRadius</td>
-            </tr>
         </table>
     }
 	


### PR DESCRIPTION
Tidal, mex cloud radius, wind -> ZK no longer uses these so displaying them just makes newbies confused.