### PR TITLE
Revert "Draw a "featured" tag on map's page"

### DIFF
--- a/Zero-K.info/Views/Maps/MapTags.cshtml
+++ b/Zero-K.info/Views/Maps/MapTags.cshtml
@@ -4,9 +4,6 @@
   Layout = "";
 }
 
-@if (m.FeaturedOrder != 0) {
-  <img src='/img/star_40.png' style="width: 32px; height: 32px" title="Map is featured" />
-}
 @if (m.MapIsFfa == true) {
   <img src='/img/map_tags/ffa.png' style="width: 32px; height: 32px" title="Free For All" />
 }
@@ -22,4 +19,3 @@
 @if (m.MapIsAssymetrical == true) {
   <img src='/img/map_tags/assymetrical.png' style="width: 32px; height: 32px" title="Map layout is asymmetrical" />
 }
- 


### PR DESCRIPTION
Reverts ZeroK-RTS/Zero-K-Infrastructure#817

Turns out that file was also used for http://test.zero-k.info/Maps so now there's two featured icons. Also there was a bug, it should've been "m.FeaturedOrder != null". I'll have to add the check to https://github.com/ZeroK-RTS/Zero-K-Infrastructure/blob/master/Zero-K.info/Views/Maps/Detail.cshtml instead.