### PR TITLE
Proper featured map tags

### DIFF
--- a/Zero-K.info/Views/Maps/Detail.cshtml
+++ b/Zero-K.info/Views/Maps/Detail.cshtml
@@ -33,7 +33,11 @@
             <img src='/Resources/@(m.MetalmapName)' style='width:@(size.Width)px; height:@(size.Height)px' class='zoom' />
         </a>
     </div>
-    <h2>@m.InternalName</h2>
+    <h2>@m.InternalName 
+	@if (m.FeaturedOrder != null) {
+		<img src="/img/star_40.png" title="Featured" alt="Featured">
+	}
+	</h2>
     @if (planet!=null) {
         <h2>Planet @Html.PrintPlanet(planet)</h2>
     }

--- a/Zero-K.info/Views/Maps/MapTags.cshtml
+++ b/Zero-K.info/Views/Maps/MapTags.cshtml
@@ -4,9 +4,6 @@
   Layout = "";
 }
 
-@if (m.FeaturedOrder != 0) {
-  <img src='/img/star_40.png' style="width: 32px; height: 32px" title="Map is featured" />
-}
 @if (m.MapIsFfa == true) {
   <img src='/img/map_tags/ffa.png' style="width: 32px; height: 32px" title="Free For All" />
 }
@@ -22,4 +19,3 @@
 @if (m.MapIsAssymetrical == true) {
   <img src='/img/map_tags/assymetrical.png' style="width: 32px; height: 32px" title="Map layout is asymmetrical" />
 }
- 


### PR DESCRIPTION
Revert "Draw a "featured" tag on map's page"
This reverts commit 6fad03a35d5eda865490d66ea26bad9095c86cd0.

Add "Featured" tag to detailed map page. This time the tag is not drawn next to all other tags (and thus drawn twice on the map list), but instead only added to the end of the map name on map-specific pages.

![zk2](https://cloud.githubusercontent.com/assets/132906/10309586/b04a1ea6-6c3d-11e5-8730-3d1667598d44.png)