### PR TITLE
Fixes some minor maplist quirks.

### DIFF
--- a/Zero-K.info/Views/Maps/MapTileList.cshtml
+++ b/Zero-K.info/Views/Maps/MapTileList.cshtml
@@ -11,7 +11,7 @@
       }
       <br />
       @m.AuthorName<br />
-      <table>
+      <table width="100%">
         <tr>
           <td valign='top'>
             <span style="margin: 0; padding: 0; border: 1px dashed gray; display: table-cell;


### PR DESCRIPTION
![zk](https://cloud.githubusercontent.com/assets/132906/10310457/58698dca-6c42-11e5-8e9a-06bdd9d7f0f9.png)
This also means map tags will occasionally fill less lines and just makes better use of space in general. The reason this width used to be different for each map is the variable rating bar.