### PR TITLE
Remove "chat with myself" link

### DIFF
--- a/Zero-K.info/Views/Shared/UserDetail.cshtml
+++ b/Zero-K.info/Views/Shared/UserDetail.cshtml
@@ -123,8 +123,9 @@
                 }
             
             
-
-                <a href="@Html.PrintSpringLink("chat/user/" + Model.Name)"> Chat with @Model.Name in the lobby </a><br />
+		@if (Model.AccountID != Global.AccountID) {
+                	<a href="@Html.PrintSpringLink("chat/user/" + Model.Name)"> Chat with @Model.Name in the lobby </a><br />
+            	}
                 @if (Model.IsZeroKAdmin) {
                     <div>
                         <b> @Model.Name </b> is a <b>Zero-K Administrator</b>


### PR DESCRIPTION
Fixes #220

This removes "Chat with xxx in the lobby" from user xxx's profile when the profile page is viewed by xxx. In other words, when I visit my own profile page (or zero-k.info) while logged in I wont see the link.

That thing:
![zk](https://cloud.githubusercontent.com/assets/132906/10322895/35b6f8e2-6c80-11e5-8e40-ccff1539792d.png)