### PR TITLE
fixes menu/nav-bar link tooltip positions

### DIFF
--- a/Zero-K.info/Styles/menu.css
+++ b/Zero-K.info/Styles/menu.css
@@ -17,8 +17,9 @@ div#menu a:hover span
 	background: #000;
 	color: #cbd3d4;
 	left: 100%; width: 125px;
-	margin-top:-1.55em; /*display tooltip at same height as :hover'ed link*/
-	padding: 5px; margin: 10px;
+	margin-top: -1.55em; /*display tooltip at same height as :hover'ed link*/
+	margin-left: 10px;
+	padding: 5px;
 	border: 1px solid #222;
 	
 	border-radius: 10px 10px 10px 10px ;


### PR DESCRIPTION
Oops! Apparently order is important. "margin" overwrote "margin-top". Anyway, I renamed it to "margin-left" because we don't really care about the other ends. This should be a good way to show what really matters.