### PR TITLE
fixes navbar for people with large default font

### DIFF
--- a/Zero-K.info/Styles/menu.css
+++ b/Zero-K.info/Styles/menu.css
@@ -6,6 +6,7 @@ div#menu a /*menu bar*/
 	display: block;
 	position: relative; /* tooltips use "absolute" position, so parent must not be static */
 	font-family: sm, sans-serif;
+	font-size: 14px;
 }
 
 div#menu a span {display:none;} /*menu text sayings*/
@@ -35,7 +36,7 @@ div#menu a:hover span
 
 ul.menu > li > a /* menu links */
 {
-	padding:10px;
+	padding:8px;
 	text-align: center; 
 }
 


### PR DESCRIPTION
People can still have their browser set to have an extreme minimum font size like 40 and break it, but that can always happen. Some day there should also be a small change to the HTML part of the navbar table, but that's not critical.