### PR TITLE
CSS: .textbutton changes and small cleanups

### DIFF
--- a/Zero-K.info/Styles/style.css
+++ b/Zero-K.info/Styles/style.css
@@ -2,8 +2,8 @@
 
 html
 {
-    /*background: #000 url("/img/bg_bluehex.gif") fixed;*/
-    background: #000;
+	/*background: #000 url("/img/bg_bluehex.gif") fixed;*/
+	background: #000;
 	color: #ede;
 	font-family: font, sans-serif;
 	font-size: 1em;
@@ -17,28 +17,28 @@ html
 
 body
 {
-    background: none;
-    width: 100%;
-    top: 0;
-    padding: 0;
-    margin: 0;
-    border: 0;
+	background: none;
+	width: 100%;
+	top: 0;
+	padding: 0;
+	margin: 0;
+	border: 0;
 }
 
 pre {
-    white-space: pre-wrap;
+	white-space: pre-wrap;
 }
 
 #fadetoblack
 {
 	background: url("/img/fade.png") repeat-y 50% 0;
-    position: fixed;
-    top: 0px;
-    left: 0px;
-    right: 0px;
-    bottom: 0px;
-    height: 100%;
-    width: 100%;
+	position: fixed;
+	top: 0px;
+	left: 0px;
+	right: 0px;
+	bottom: 0px;
+	height: 100%;
+	width: 100%;
 }
 
 .wrapper
@@ -61,8 +61,8 @@ div#footer
 
 .floatingheader
 {
-    position:fixed;
-    top:10px;
+	position:fixed;
+	top:10px;
 	margin-left: auto;
 	margin-right: auto;
 	z-index:100;
@@ -70,8 +70,8 @@ div#footer
 
 .floatingfooter
 {
-    position:fixed;
-    bottom:-10px;
+	position:fixed;
+	bottom:-10px;
 	margin-left: auto;
 	margin-right: auto;
 	z-index:100;
@@ -79,8 +79,8 @@ div#footer
 
 ul.forumtab
 {
-    list-style-image: url("/img/bullet.png");
-    padding-left: 15px;
+	list-style-image: url("/img/bullet.png");
+	padding-left: 15px;
 }
 
 hr.pretty
@@ -92,7 +92,7 @@ hr.pretty
 
 div#simplestyle
 {
-    margin: 10px;
+	margin: 10px;
 }
 
 div#busy
@@ -125,34 +125,34 @@ div#busy
 {
 	margin: 10px;
 	padding: 5px;
-    border-style: solid;
+	border-style: solid;
 	border-radius: 15px;
 	border-image:url("/styles/dark-hive/images/tech_button.png") 24 fill / 15px stretch;
 	background: #333;
-    box-shadow: 0 0 3px 3px #000;
+	box-shadow: 0 0 3px 3px #000;
 	-moz-box-shadow: 0 0 3px 3px #000;
-    -webkit-box-shadow: 0 0 3px 3px #000;
+	-webkit-box-shadow: 0 0 3px 3px #000;
 }
 
 .ie .border
 {
-    padding: 13px;
+	padding: 13px;
 	border: 1px solid #38bfec;
 }
 
 /* Download-Button on Homepage */
 .buttonSpan
 {
-    height: 45px;
-    width: 45px;
-    background-image: url("/img/downloadBlue45.png");
-    display: inline-block;
-    vertical-align:middle;
+	height: 45px;
+	width: 45px;
+	background-image: url("/img/downloadBlue45.png");
+	display: inline-block;
+	vertical-align:middle;
 }
 
 .buttonSpan:hover
 {
-    background-image: url("/img/downloadBlue45_2.png");
+	background-image: url("/img/downloadBlue45_2.png");
 }
 
 .textbutton
@@ -162,21 +162,20 @@ div#busy
 	color: #38bfec;
 	border-radius: 5px;
 	border: 1px solid #2a8eaf;
-    box-shadow: 0 0 2px 2px #38bfec;
-	padding: 2px;
-	padding-left: 6px;
-	padding-right: 6px;
-	margin: 4px 1px 4px 1px;
+	box-shadow: 0 0 2px 2px #38bfec;
+	padding: 0.4em 1em;
+	margin: 4px 1px;
 	cursor: pointer;
-    text-align: center;
-    font-family: skir, sans-serif;
+	text-align: center;
+	font-family: skir, sans-serif;
+	font-size
 }
 
 .textbutton:hover
 {
 	color: #fff;
-    box-shadow: 0 0 2px 2px #fff;
-    text-decoration: none;
+	box-shadow: 0 0 2px 2px #fff;
+	text-decoration: none;
 }
 
 .downloadbutton
@@ -187,31 +186,31 @@ div#busy
 	color: #38bfec;
 	border-radius: 5px;
 	border: 1px solid #2a8eaf;
-    box-shadow: 0 0 2px 2px #38bfec;
-	padding: 15px 0 15px 0;
+	box-shadow: 0 0 2px 2px #38bfec;
+	padding: 15px 0;
 	margin: 10px;
 	cursor: pointer;
-    text-align: center;
-    font-family: skir, sans-serif;
-    font-size: 200%;
+	text-align: center;
+	font-family: skir, sans-serif;
+	font-size: 200%;
 }
 
 .downloadbutton:hover
 {
 	color: #fff;
-    box-shadow: 0 0 2px 2px #fff;
+	box-shadow: 0 0 2px 2px #fff;
 }
 
 .downloadbutton:active
 {
 	color: #cbd3d4;
-    box-shadow: 0 0 2px 2px #cbd3d4;
+	box-shadow: 0 0 2px 2px #cbd3d4;
 }
 
 div.button_2
 {
-    position:static;
-    display:inline-block;
+	position:static;
+	display:inline-block;
 	left: 60px;
 	width: 197px;
 	height: 43px;
@@ -223,7 +222,6 @@ div.button_2
 	text-align: center;
 	vertical-align:middle;
 	opacity: 1;
-	
 }
 
 div.button_2:hover {
@@ -232,20 +230,20 @@ div.button_2:hover {
 
 span.button_2text
 {
-    font-family: 'Klavika', Helvetica, Arial, sans-serif;
-    color: #FFF;
-    font-size: large;
-    line-height: 1;
-    text-decoration: none;
-    text-align: center;
-    position: relative;
-    top: 9px;
+	font-family: 'Klavika', Helvetica, Arial, sans-serif;
+	color: #FFF;
+	font-size: large;
+	line-height: 1;
+	text-decoration: none;
+	text-align: center;
+	position: relative;
+	top: 9px;
 }
 
 /* Share */
 #shares 
 {
-    vertical-align:middle;
+	vertical-align:middle;
 }
 
 /* galaxy map
@@ -357,9 +355,9 @@ span.button_2text
 	padding: 5px;
 	margin: 2px;
 	border-radius: 5px;
-    box-shadow: 0 0 3px 3px #000;
+	box-shadow: 0 0 3px 3px #000;
 	-moz-box-shadow: 0 0 3px 3px #000;
-    -webkit-box-shadow: 0 0 3px 3px #000;
+	-webkit-box-shadow: 0 0 3px 3px #000;
 }
 
 .battle_loser
@@ -368,9 +366,9 @@ span.button_2text
 	padding: 5px;
 	margin: 2px;
 	border-radius: 5px;
-    box-shadow: 0 0 3px 3px #000;
+	box-shadow: 0 0 3px 3px #000;
 	-moz-box-shadow: 0 0 3px 3px #000;
-    -webkit-box-shadow: 0 0 3px 3px #000;
+	-webkit-box-shadow: 0 0 3px 3px #000;
 }
 
 .battle_spec
@@ -412,36 +410,36 @@ span.button_2text
 -----------------------------------------------------------*/
 .field-validation-error
 {
-    color: #ff0000;
+	color: #ff0000;
 }
 
 .field-validation-valid
 {
-    display: none;
+	display: none;
 }
 
 .input-validation-error
 {
-    border: 1px solid #ff0000;
-    background-color: #ffeeee;
+	border: 1px solid #ff0000;
+	background-color: #ffeeee;
 }
 
 .validation-summary-errors
 {
-    font-weight: bold;
-    color: #ff0000;
+	font-weight: bold;
+	color: #ff0000;
 }
 
 .validation-summary-valid
 {
-    display: none;
+	display: none;
 }
 
 /* google wiki */
 .section_anchor 
 {
-  display:none;
-  color: Black;
+	display:none;
+	color: Black;
 }
 
 /* Styles for unitguide
@@ -449,31 +447,31 @@ span.button_2text
 
 .infoCell
 {
-  background-color:#204040;
-  border-style: solid;
-  border-image: url("/styles/dark-hive/images/tech_button.png") 24 24 24 24 fill / 15px 15px 15px 15px;
-  border-radius: 10px;
-  border-color:transparent;
-  max-width: 700px;
-  overflow: hidden;
-  padding:10px;
-  white-space:normal;
+	background-color:#204040;
+	border-style: solid;
+	border-image: url("/styles/dark-hive/images/tech_button.png") 24 24 24 24 fill / 15px 15px 15px 15px;
+	border-radius: 10px;
+	border-color:transparent;
+	max-width: 700px;
+	overflow: hidden;
+	padding:10px;
+	white-space:normal;
 }
 .unitCell{
-    margin-left: 30px; 
+	margin-left: 30px; 
 }
 .unitname {
-    font-weight:bold;
+	font-weight:bold;
 }
-.unitdesc  {
-    font-style:oblique;
+.unitdesc {
+	font-style:oblique;
 }
 .helptext {
 	font-size:small;
 }
 
 .buildpic {
-    border: 1px solid white;
+	border: 1px solid white;
 }
 .statsnumval {
 	font-weight:bold;
@@ -487,92 +485,92 @@ span.button_2text
 
 .forumRow 
 {
-  width:100%;
+	width:100%;
 }
 
 .forumPostHead 
 {
-  background-color:#204040;
-  width:222px;
-  border-style: solid;
-  border-radius:10px;
-  border-color:transparent;
-  border-image: url("/styles/dark-hive/images/tech_button.png") 24 24 24 24 fill / 15px 15px 15px 15px;
-  padding:10px;
+	background-color:#204040;
+	width:222px;
+	border-style: solid;
+	border-radius:10px;
+	border-color:transparent;
+	border-image: url("/styles/dark-hive/images/tech_button.png") 24 24 24 24 fill / 15px 15px 15px 15px;
+	padding:10px;
 }
 
 .forumPostText
 {
-  background-color:#204040;
-  border-style: solid;
-  border-image: url("/styles/dark-hive/images/tech_button.png") 24 24 24 24 fill / 15px 15px 15px 15px;
-  border-radius: 10px;
-  border-color:transparent;
-  max-width: 700px;
-  overflow: hidden;
-  padding:10px;
-  white-space:normal;
+	background-color:#204040;
+	border-style: solid;
+	border-image: url("/styles/dark-hive/images/tech_button.png") 24 24 24 24 fill / 15px 15px 15px 15px;
+	border-radius: 10px;
+	border-color:transparent;
+	max-width: 700px;
+	overflow: hidden;
+	padding:10px;
+	white-space:normal;
 }
 
 .forumPostText img
 {
-  max-width:100%;
+	max-width:100%;
 }
 
 .journal img {
-  max-width:100%;
+	max-width:100%;
 }
 
 /* planetwars */
 .planetname
 {
-  text-shadow:-1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+	text-shadow:-1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
 }
 
 .pwlabel 
 {
-  font-size:11px; 
-  font-weight:bold; 
-  margin: 0; 
-  padding:0; 
-  position: absolute;
+	font-size:11px; 
+	font-weight:bold; 
+	margin: 0; 
+	padding:0; 
+	position: absolute;
 }
 
 .wikitable {
-   border-spacing: 0;
-   border: 1px solid #ccc;
+	border-spacing: 0;
+	border: 1px solid #ccc;
 }
 
 .wikitable td {
-    border: 1px solid #ccc; padding: 5px;
+	border: 1px solid #ccc; padding: 5px;
 }
 
 
 .grid {
-    margin: 10px;
-    padding: 5px;
-    border-style: solid;
-    border-radius: 15px;
-    border-image: url("/styles/dark-hive/images/tech_button.png") 24 fill / 15px stretch;
-    background: #333;
-    box-shadow: 0 0 3px 3px #000;
-    -moz-box-shadow: 0 0 3px 3px #000;
-    -webkit-box-shadow: 0 0 3px 3px #000;
-    margin: 5px;
-    
+	margin: 10px;
+	padding: 5px;
+	border-style: solid;
+	border-radius: 15px;
+	border-image: url("/styles/dark-hive/images/tech_button.png") 24 fill / 15px stretch;
+	background: #333;
+	box-shadow: 0 0 3px 3px #000;
+	-moz-box-shadow: 0 0 3px 3px #000;
+	-webkit-box-shadow: 0 0 3px 3px #000;
+	margin: 5px;
 }
+
 .grid_title {
-   text-align: center;
+	text-align: center;
 }
 
 .grid_table {
-    width: 100%;    
+	width: 100%;
 }
 
 .grid_pager {
-    margin: 4px;
+	margin: 4px;
 }
 
 .grid .row_selected {
-    background-color: #0000cd;
+	background-color: #0000cd;
 }


### PR DESCRIPTION
.textbutton changes:

Added font-size:medium; to stop browsers from overwriting <input> fontsizes
Merged paddings to padding:0.4em 1em; to be the same as input.ui-button in jquery-ui.css
Added vertical-align:middle; to make sure <span> (default vertical-align:baseline) properly lines up with all the other buttons


Cleanups that don't affect styles, semantics unchanged:

In line 169 (now 197), shortened margin: 4px 1px 4px 1px; to margin: 4px 1px;
In line 191 (now 190), shortened padding: 15px 0 15px 0; to padding: 15px 0;
(see "The padding property can have from one to four values." on http://www.w3schools.com/css/css_padding.asp for a short explanation)
Also removed some empty lines, blank spaces at the end of lines and changed all blank space indents (usually four, sometimes two and five blank spaces) to use tab instead.