### PR TITLE
Replace "Social Media" logos with simpler/non-404 resources

### DIFF
--- a/Zero-K.info/Views/Home/HomeIndex.cshtml
+++ b/Zero-K.info/Views/Home/HomeIndex.cshtml
@@ -128,7 +128,7 @@
     <div class="border">
         <h2>Social Media</h2>
         <a href="https://www.facebook.com/ZeroK.RTS"><img src="https://www.facebookbrand.com/img/assets/asset.f.logo.lg.png" class="icon32"/></a>
-        <a href="https://github.com/ZeroK-RTS"><img src="http://civicio.files.wordpress.com/2013/03/github.png?w=256&h=256" class="icon32"></a>
+        <a href="https://github.com/ZeroK-RTS"><img src="http://i.imgur.com/BItG041.png" class="icon32"></a>
         <a href="http://steamcommunity.com/groups/0-K"><img src="https://upload.wikimedia.org/wikipedia/en/4/48/Steam_Icon_2014.png" class="icon32" /></a>
         <a href="@Url.Action("Index", "News")"><img src="https://upload.wikimedia.org/wikipedia/en/thumb/4/43/Feed-icon.svg/128px-Feed-icon.svg.png" class="icon32"/></a>
         <a href="https://plus.google.com/+Zero-kInfo/"><img src="https://plus.google.com/favicon.ico" class="icon32"/></a>

--- a/Zero-K.info/Views/Home/HomeIndex.cshtml
+++ b/Zero-K.info/Views/Home/HomeIndex.cshtml
@@ -128,8 +128,8 @@
     <div class="border">
         <h2>Social Media</h2>
         <a href="https://www.facebook.com/ZeroK.RTS"><img src="https://www.facebookbrand.com/img/assets/asset.f.logo.lg.png" class="icon32"/></a>
-        <a href="https://github.com/ZeroK-RTS"><img src="http://i.imgur.com/BItG041.png" class="icon32"></a>
-        <a href="http://steamcommunity.com/groups/0-K"><img src="https://upload.wikimedia.org/wikipedia/en/4/48/Steam_Icon_2014.png" class="icon32" /></a>
+        <a href="https://github.com/ZeroK-RTS"><img src="https://i.imgur.com/BItG041.png" class="icon32"></a>
+        <a href="http://steamcommunity.com/groups/0-K"><img src="https://upload.wikimedia.org/wikipedia/commons/8/83/Steam_icon_logo.svg" class="icon32" /></a>
         <a href="@Url.Action("Index", "News")"><img src="https://upload.wikimedia.org/wikipedia/en/thumb/4/43/Feed-icon.svg/128px-Feed-icon.svg.png" class="icon32"/></a>
         <a href="https://plus.google.com/+Zero-kInfo/"><img src="https://plus.google.com/favicon.ico" class="icon32"/></a>
         <a href="http://twitter.com/ZeroKTeam"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/Twitter_Logo_Mini.svg/220px-Twitter_Logo_Mini.svg.png" class="icon32"/></a>


### PR DESCRIPTION
The current version looks pretty weird and is hard to read on the near-black background. This change should ensure (new) visitors notice the Github symbol. Here's what the new image looks like: http://i.imgur.com/c1J59Dy.png

I took the new logo "GitHub-Mark-Light-32px.png" straight from https://github.com/logos