### PR TITLE
Support for free unlocks

### DIFF
--- a/Zero-K.info/Views/My/CommanderProfile.cshtml
+++ b/Zero-K.info/Views/My/CommanderProfile.cshtml
@@ -30,9 +30,9 @@ Commander name: @Html.TextBox("name", c != null ? HttpContext.Current.Server.Htm
             }
             else
             {
-	    		@Html.DropDownList("m" + slot.CommanderSlotID, Model.Unlocks.Where(x => MyController.IsUnlockValidForSlot(x, slot)
-                    && MyController.IsPrerequisiteUnlockPresent(c, x)).Select(x => new SelectListItem()
-                    { Text = x.Name, Value = x.UnlockID.ToString(), Selected = c != null ? c.CommanderModules.Any(y => y.ModuleUnlockID == x.UnlockID && y.SlotID == slot.CommanderSlotID) : false }).Union(new SelectListItem[] 
+	    		@Html.DropDownList("m" + slot.CommanderSlotID, Model.Unlocks.Where(x => MyController.IsUnlockValidForSlot(x.Unlock, slot)
+                    && MyController.IsPrerequisiteUnlockPresent(c, x.Unlock)).Select(x => new SelectListItem()
+                    { Text = x.Unlock.Name, Value = x.Unlock.UnlockID.ToString(), Selected = c != null ? c.CommanderModules.Any(y => y.ModuleUnlockID == x.Unlock.UnlockID && y.SlotID == slot.CommanderSlotID) : false }).Union(new SelectListItem[] 
                     { new SelectListItem() { Text = "", Value = "", Selected = c != null ? !c.CommanderModules.Any(y => y.SlotID == slot.CommanderSlotID) : true } }), 
                     new { onchange = "document.getElementById(\"commanderUpdate" + Model.ProfileID + "\").click()" })
             }
@@ -53,9 +53,9 @@ Commander name: @Html.TextBox("name", c != null ? HttpContext.Current.Server.Htm
         }
         else
         {
-	    	@Html.DropDownList("d" + decSlot.CommanderDecorationSlotID, Model.Unlocks.Where(x => x.UnlockType == UnlockTypes.Decoration).Select(x => new SelectListItem() { 
-                Text = x.Name, Value = x.UnlockID.ToString(), Selected = c != null ? 
-                c.CommanderDecorations.Any(y => y.DecorationUnlockID == x.UnlockID && y.SlotID == decSlot.CommanderDecorationSlotID) : false }).Union(new SelectListItem[] 
+	    	@Html.DropDownList("d" + decSlot.CommanderDecorationSlotID, Model.Unlocks.Where(x => x.Unlock.UnlockType == UnlockTypes.Decoration).Select(x => new SelectListItem() { 
+                Text = x.Unlock.Name, Value = x.Unlock.UnlockID.ToString(), Selected = c != null ? 
+                c.CommanderDecorations.Any(y => y.DecorationUnlockID == x.Unlock.UnlockID && y.SlotID == decSlot.CommanderDecorationSlotID) : false }).Union(new SelectListItem[] 
                 { new SelectListItem() { Text = "", Value = "", Selected = c != null ? !c.CommanderDecorations.Any(y => y.SlotID == decSlot.CommanderDecorationSlotID) : true } }), 
                 new { onchange = "document.getElementById(\"commanderUpdate" + Model.ProfileID + "\").click()" })
         }
@@ -65,5 +65,6 @@ Commander name: @Html.TextBox("name", c != null ? HttpContext.Current.Server.Htm
 }
 else
 { 
-	@:Chassis: @Html.DropDownList("chassis", Model.Unlocks.Where(x => x.UnlockType == ZkData.UnlockTypes.Chassis).Select(x => new SelectListItem() { Text = x.Name, Value = x.UnlockID.ToString(), Selected = (c != null ? c.ChassisUnlockID == x.UnlockID : false) }))
+	@:Chassis: @Html.DropDownList("chassis", Model.Unlocks.Where(x => x.Unlock.UnlockType == ZkData.UnlockTypes.Chassis).Select(x => new SelectListItem()
+          { Text = x.Unlock.Name, Value = x.Unlock.UnlockID.ToString(), Selected = (c != null ? c.ChassisUnlockID == x.Unlock.UnlockID : false) }))
 }

--- a/Zero-K.info/Views/My/UnlockList.cshtml
+++ b/Zero-K.info/Views/My/UnlockList.cshtml
@@ -1,7 +1,7 @@
 ﻿@model ZeroKWeb.Controllers.MyController.UnlockListResult
 @{Page.Title = "Technology unlocks";}
 <center><h2>Owned technologies</h2></center>
-@{Html.RenderPartial("UnlockedTechnologies", Model.Account.AccountUnlocks.ToList().OrderBy(x => x.Unlock.UnlockType).ThenBy(x => x.Unlock.Name));}
+@{Html.RenderPartial("UnlockedTechnologies", Model.AlreadyUnlockedCounts);}
 
 <div class="border" style="position: fixed; bottom: 10%; left: 40%; z-index: 100; border: #fff;" title="Want more points? <br /> First you have to reach the next level before you'll receive new points. <br /> Gain XP just by playing the game, win or lose!">
 	<h3>You have <span style="color: red; font-size: 130%;"> @Model.Account.AvailableXP </span> points available</h3>

--- a/Zero-K.info/Views/Shared/UnlockedTechnologies.cshtml
+++ b/Zero-K.info/Views/Shared/UnlockedTechnologies.cshtml
@@ -1,4 +1,5 @@
- @model IEnumerable<ZkData.AccountUnlock>
+@model IEnumerable<MyController.UnlockCountEntry>
+@using ZeroKWeb.Controllers
 <div>
 @foreach (var au in Model) {
   var unlock = au.Unlock;

--- a/Zero-K.info/Views/Shared/UserDetail.cshtml
+++ b/Zero-K.info/Views/Shared/UserDetail.cshtml
@@ -232,7 +232,7 @@
             }
             <br />
             <!--div>
-                @Html.Partial("UnlockedTechnologies", Model.AccountUnlocks)
+                @*@Html.Partial("UnlockedTechnologies", Model.AccountUnlocks)*@
             </div-->
             @if (Model.AccountID == Global.AccountID)
             {


### PR DESCRIPTION
Modules with XpCost <= 0 and not kudos-exclusive are treated as unlocked (to maximum count) if player meets the required level.

(This is intended to facilitate making all current unlocks on site free for all players, now that dynamic comms are here)