### PR TITLE
Do not extend !kick time upon rejoin attempt

### DIFF
--- a/Springie/Springie/autohost/AutoHost_commands.cs
+++ b/Springie/Springie/autohost/AutoHost_commands.cs
@@ -354,7 +354,7 @@ namespace Springie.autohost
                 return;
             }
 
-            kickedPlayers.Add(new KickedPlayer() {Name = usrlist[0]});
+            if (!kickedPlayers.Any(x => x.Name == usrlist[0])) kickedPlayers.Add(new KickedPlayer() {Name = usrlist[0]});
             if (spring.IsRunning) spring.Kick(usrlist[0]);
             tas.Kick(usrlist[0]);
         }


### PR DESCRIPTION
Extension of the kick time is undocumented. People with malicious intent who might have experience/knowledge about this concept are the most likely to circumvent it, while others only get needlessly confused and punished.