### PR TITLE
Don't consider a player active on the ladder if they only speced games lately

### DIFF
--- a/Zero-K.info/Controllers/LaddersController.cs
+++ b/Zero-K.info/Controllers/LaddersController.cs
@@ -137,7 +137,7 @@ namespace ZeroKWeb.Controllers
 
             var ladderTimeout = DateTime.UtcNow.AddDays(-GlobalConst.LadderActivityDays);
             var top50Accounts =
-                db.Accounts.Where(x => x.SpringBattlePlayers.Any(y => y.SpringBattle.StartTime > ladderTimeout))
+                db.Accounts.Where(x => x.SpringBattlePlayers.Any(y => y.SpringBattle.StartTime > ladderTimeout && !y.IsSpectator))
                     .Include(x => x.Clan)
                     .Include(x => x.Faction)
                     .OrderByDescending(x => x.Effective1v1Elo)
@@ -146,7 +146,7 @@ namespace ZeroKWeb.Controllers
                     .ToList();
 
             var top50Teams =
-                db.Accounts.Where(x => x.SpringBattlePlayers.Any(y => y.SpringBattle.StartTime > ladderTimeout))
+                db.Accounts.Where(x => x.SpringBattlePlayers.Any(y => y.SpringBattle.StartTime > ladderTimeout && !y.IsSpectator))
                     .Include(x => x.Clan)
                     .Include(x => x.Faction)
                     .OrderByDescending(x => x.EffectiveElo)


### PR DESCRIPTION
I didn't test it locally, but I think it's minor enough to be probably correct :D

I wanted to check whether a game was actually ranked (then you could also check whether they're 1v1/team games), but I'm not sure if it's possible and how.