### PR TITLE
ZKL: Replace GDI+ text functions where possible

### DIFF
--- a/ZeroKLobby/MicroLobby/BattleIcon.cs
+++ b/ZeroKLobby/MicroLobby/BattleIcon.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Linq;
 using LobbyClient;
+using System.Windows.Forms;
 
 namespace ZeroKLobby.MicroLobby
 {
@@ -240,22 +241,21 @@ namespace ZeroKLobby.MicroLobby
                 int y = (int)3;
                 int offset = (int)16;
                 int curMapCellSize = (int)MapCellSize.Width;
-                g.DrawString(Battle.Title, TitleFont, TextBrush, curMapCellSize, y + offset * 0);
-                if (g.MeasureString(mod_and_engine_name, ModFont).Width < scaledWidth - curMapCellSize)
+                TextRenderer.DrawText(g, Battle.Title, TitleFont, new Point(curMapCellSize, y + offset * 0), Config.TextColor);
+                //g.DrawString(Battle.Title, TitleFont, TextBrush, curMapCellSize, y + offset * 0);
+                if (TextRenderer.MeasureText(mod_and_engine_name, ModFont).Width < scaledWidth - curMapCellSize)
                 {
-                    g.DrawString(mod_and_engine_name, ModFont, TextBrush, curMapCellSize, y + offset * 1);
+                    TextRenderer.DrawText(g, mod_and_engine_name, ModFont, new Point(curMapCellSize, y + offset * 1), Config.TextColor);
+                    //g.DrawString(mod_and_engine_name, ModFont, TextBrush, curMapCellSize, y + offset * 1);
                     g.DrawImageUnscaled(playersBoxImage, curMapCellSize, y + offset * 2);
                 }
                 else
                 {
                     int offset_offset = (int)4; //this squishes modName & engine-name and dude-icons together abit
                     int offset_offset2 = (int)6; //this squished modName & engine-name into 2 tight lines
-                    g.DrawString(Battle.ModName, ModFont, TextBrush, curMapCellSize, y + offset * 1 - offset_offset);
-                    g.DrawString(string.Format("{0}{1}", Battle.EngineName, Battle.EngineVersion),
-                        ModFont,
-                        TextBrush,
-                        curMapCellSize,
-                        y + offset * 2 - offset_offset - offset_offset2);
+                    TextRenderer.DrawText(g, Battle.ModName, ModFont, new Point(curMapCellSize, y + offset * 1 - offset_offset), Config.TextColor);
+                    TextRenderer.DrawText(g, string.Format("{0}{1}", Battle.EngineName, Battle.EngineVersion), 
+                        ModFont, new Point(curMapCellSize, y + offset * 2 - offset_offset - offset_offset2), Config.TextColor);
                     g.DrawImageUnscaled(playersBoxImage, curMapCellSize, y + offset * 3 - offset_offset - offset_offset2);
                 }
                 g.ResetClip();

--- a/ZeroKLobby/MicroLobby/TextWindow.cs
+++ b/ZeroKLobby/MicroLobby/TextWindow.cs
@@ -520,13 +520,8 @@ namespace ZeroKLobby.MicroLobby
 
                 textLines[totalLines].Line = newLine;
 
-                var g = CreateGraphics();
                 //properly measure for bold characters needed
-                var sf = StringFormat.GenericTypographic;
-                sf.FormatFlags |= StringFormatFlags.MeasureTrailingSpaces;
-                textLines[totalLines].Width = (int)g.MeasureString(TextColor.StripCodes(newLine), Font, 0, sf).Width;
-
-                g.Dispose();
+                textLines[totalLines].Width = TextRenderer.MeasureText(TextColor.StripCodes(newLine), Font).Width;
 
                 textLines[totalLines].TextColor = foreColor;
 
@@ -583,12 +578,6 @@ namespace ZeroKLobby.MicroLobby
             var nextColor = "";
 
             var ii = line;
-            var g = CreateGraphics();
-
-            var sf = StringFormat.GenericTypographic;
-            sf.FormatFlags |= StringFormatFlags.MeasureTrailingSpaces;
-
-            g.TextRenderingHint = TextRenderingHint.AntiAlias;
 
             for (var currentLine = endLine; currentLine <= startLine; currentLine++)
             {
@@ -650,7 +639,7 @@ namespace ZeroKLobby.MicroLobby
                                     break;
                                 default:
                                     //check if there needs to be a linewrap
-                                    if (g.MeasureString(buildString.ToString().StripAllCodes(), Font, 0, sf).Width + emotSpace > displayWidth)
+                                    if (TextRenderer.MeasureText(buildString.ToString().StripAllCodes(), Font).Width + emotSpace > displayWidth)
                                     {
                                         if (lineSplit) displayLines[line].Line = lastColor + buildString;
                                         else displayLines[line].Line = buildString.ToString();
@@ -697,9 +686,6 @@ namespace ZeroKLobby.MicroLobby
                         AddNewDisplayLines();
                 }
             }
-
-            sf.Dispose();
-            g.Dispose();
 
             return line;
         }
@@ -843,6 +829,7 @@ namespace ZeroKLobby.MicroLobby
                                     using (SolidBrush backColorBrush = new SolidBrush(TextColor.GetColor(curBackColor))) //refresh backcolor
                                     {
                                         ch = line.ToString().Substring(i, 1).ToCharArray();
+                                        // why does this switch statement duplicate so much code?
                                         switch (ch[0])
                                         {
                                             case TextColor.EmotChar: //this header is added by SaidLine.cs & SaidLineEx.cs
@@ -858,27 +845,19 @@ namespace ZeroKLobby.MicroLobby
 
                                                     if (curBackColor != backColor)
                                                     {
-                                                        textSize = (int)g.MeasureString(buildString.ToString(), Font, 0, sf).Width + 1;
+                                                        textSize = TextRenderer.MeasureText(buildString.ToString(), Font).Width + 1;
                                                         var r = new Rectangle((int)startX, startY, textSize + 1, LineSize + 1);
                                                         g.FillRectangle(backColorBrush, r); //draw white (or black) rectangle
                                                     }
 
                                                     g.DrawImage(bm, //draw an emoticon
-                                                                startX + g.MeasureString(buildString.ToString(), Font, 0, sf).Width,
+                                                                startX + TextRenderer.MeasureText(buildString.ToString(), Font).Width,
                                                                 startY,
                                                                 16,
                                                                 16);
+                                                    TextRenderer.DrawText(g, buildString.ToString(), Font, new Point((int)startX, startY), TextColor.GetColor(curForeColor));
 
-                                                    using (var brush = new SolidBrush(TextColor.GetColor(curForeColor))) {
-                                                        g.DrawString(buildString.ToString(), //draw text (that wasn't yet drawn up to *this* point)
-                                                                        Font,
-                                                                        brush,
-                                                                        startX,
-                                                                        startY,
-                                                                        sf);
-                                                    }
-
-                                                    startX += bm.Width + g.MeasureString(buildString.ToString(), Font, 0, sf).Width;
+                                                    startX += bm.Width + TextRenderer.MeasureText(buildString.ToString(), Font).Width;
 
                                                     buildString.Clear(); //reset the content (because we already draw it for user)
                                                 }
@@ -886,21 +865,13 @@ namespace ZeroKLobby.MicroLobby
                                             case TextColor.UrlStart:
                                                 if (curBackColor != backColor)
                                                 {
-                                                    textSize = (int)g.MeasureString(buildString.ToString(), Font, 0, sf).Width + 1;
+                                                    textSize = TextRenderer.MeasureText(buildString.ToString(), Font).Width + 1;
                                                     var r = new Rectangle((int)startX, startY, textSize + 1, LineSize + 1);
                                                     g.FillRectangle(backColorBrush, r);
                                                 }
-                                                using (var brush = new SolidBrush(TextColor.GetColor(curForeColor))) {
-                                                    g.DrawString(buildString.ToString(),
-                                                                    font,
-                                                                    brush,
-                                                                    startX,
-                                                                    startY,
-                                                                    sf);
-                                                }
-                                                // TextRenderer.DrawText(g, buildString.ToString(), font, new Point((int)startX, startY), TextColor.GetColor(curForeColor), TextColor.GetColor(curBackColor)); //is slow for slow gpu IMO
+                                                TextRenderer.DrawText(g, buildString.ToString(), font, new Point((int)startX, startY), TextColor.GetColor(curForeColor), TextColor.GetColor(curBackColor));
 
-                                                startX += g.MeasureString(buildString.ToString(), font, 0, sf).Width; //textSizes[32]
+                                                startX += TextRenderer.MeasureText(buildString.ToString(), Font).Width; //textSizes[32]
 
                                                 buildString.Clear();
 
@@ -916,21 +887,13 @@ namespace ZeroKLobby.MicroLobby
                                             case TextColor.UrlEnd:
                                                 if (curBackColor != backColor)
                                                 {
-                                                    textSize = (int)g.MeasureString(buildString.ToString(), font, 0, sf).Width + 1;
+                                                    textSize = TextRenderer.MeasureText(buildString.ToString(), Font).Width + 1;
                                                     var r = new Rectangle((int)startX, startY, textSize + 1, LineSize + 1);
                                                     g.FillRectangle(backColorBrush, r);
                                                 }
-                                                // TextRenderer.DrawText(g, buildString.ToString(), font, new Point((int)startX, startY), TextColor.GetColor(curForeColor), TextColor.GetColor(curBackColor)); //is slow for slow gpu IMO
-                                                using (var brush = new SolidBrush(TextColor.GetColor(curForeColor))) {
-                                                    g.DrawString(buildString.ToString(),
-                                                                    font,
-                                                                    brush,
-                                                                    startX,
-                                                                    startY,
-                                                                    sf);
-                                                }
+                                                TextRenderer.DrawText(g, buildString.ToString(), font, new Point((int)startX, startY), TextColor.GetColor(curForeColor), TextColor.GetColor(curBackColor));
 
-                                                startX += g.MeasureString(buildString.ToString(), font, 0, sf).Width; //textSizes[32]
+                                                startX += TextRenderer.MeasureText(buildString.ToString(), Font).Width;
 
                                                 buildString.Clear();
 
@@ -945,21 +908,13 @@ namespace ZeroKLobby.MicroLobby
                                             case TextColor.UnderlineChar:
                                                 if (curBackColor != backColor)
                                                 {
-                                                    textSize = (int)g.MeasureString(buildString.ToString(), font, 0, sf).Width + 1;
+                                                    textSize = TextRenderer.MeasureText(buildString.ToString(), Font).Width + 1;
                                                     var r = new Rectangle((int)startX, startY, textSize + 1, LineSize + 1);
                                                     g.FillRectangle(backColorBrush, r);
                                                 }
-                                                // TextRenderer.DrawText(g, buildString.ToString(), font, new Point((int)startX, startY), TextColor.GetColor(curForeColor), TextColor.GetColor(curBackColor)); //is slow for slow gpu IMO
-                                                using (var brush = new SolidBrush(TextColor.GetColor(curForeColor))) {
-                                                    g.DrawString(buildString.ToString(),
-                                                                    font,
-                                                                    brush,
-                                                                    startX,
-                                                                    startY,
-                                                                    sf);
-                                                }
+                                                TextRenderer.DrawText(g, buildString.ToString(), font, new Point((int)startX, startY), TextColor.GetColor(curForeColor), TextColor.GetColor(curBackColor));
 
-                                                startX += g.MeasureString(buildString.ToString(), font, 0, sf).Width; //textSizes[32]
+                                                startX += TextRenderer.MeasureText(buildString.ToString(), Font).Width;
 
                                                 buildString.Clear();
 
@@ -977,21 +932,13 @@ namespace ZeroKLobby.MicroLobby
                                                 //draw whats previously in the string
                                                 if (curBackColor != backColor)
                                                 {
-                                                    textSize = (int)g.MeasureString(buildString.ToString(), font, 0, sf).Width + 1;
+                                                    textSize = TextRenderer.MeasureText(buildString.ToString(), Font).Width + 1;
                                                     var r = new Rectangle((int)startX, startY, textSize + 1, LineSize + 1);
                                                     g.FillRectangle(backColorBrush, r);
                                                 }
-                                                // TextRenderer.DrawText(g, buildString.ToString(), font, new Point((int)startX, startY), TextColor.GetColor(curForeColor), TextColor.GetColor(curBackColor)); //is slow for slow gpu IMO
-                                                using (var brush = new SolidBrush(TextColor.GetColor(curForeColor))) {
-                                                    g.DrawString(buildString.ToString(),
-                                                                    font,
-                                                                    brush,
-                                                                    startX,
-                                                                    startY,
-                                                                    sf);
-                                                }
+                                                TextRenderer.DrawText(g, buildString.ToString(), font, new Point((int)startX, startY), TextColor.GetColor(curForeColor), TextColor.GetColor(curBackColor));
 
-                                                startX += g.MeasureString(buildString.ToString(), font, 0, sf).Width; //textSizes[32]
+                                                startX += TextRenderer.MeasureText(buildString.ToString(), Font).Width;
 
                                                 buildString.Clear();
 
@@ -1027,25 +974,19 @@ namespace ZeroKLobby.MicroLobby
                                                 {
                                                     if (curBackColor != backColor)
                                                     {
-                                                        textSize = (int)g.MeasureString(buildString.ToString(), Font, 0, sf).Width + 1;
+                                                        textSize = TextRenderer.MeasureText(buildString.ToString(), Font).Width + 1;
                                                         var r = new Rectangle((int)startX, startY, textSize + 1, LineSize + 1);
                                                         g.FillRectangle(backColorBrush, r);
                                                     }
-                                                    using (var brush = new SolidBrush(TextColor.GetColor(curForeColor))) {
-                                                        g.DrawString(buildString.ToString(),
-                                                                     font,
-                                                                     brush,
-                                                                     startX,
-                                                                     startY,
-                                                                     sf);
-                                                    }
-                                                    startX += g.MeasureString(buildString.ToString(), font, 0, sf).Width;
+                                                    TextRenderer.DrawText(g, buildString.ToString(), font, new Point((int)startX, startY), TextColor.GetColor(curForeColor), TextColor.GetColor(curBackColor));
+
+                                                    startX += TextRenderer.MeasureText(buildString.ToString(), Font).Width;
                                                     float symbolWidth;
                                                     using (var tmpBuffer = new Bitmap(LineSize,LineSize, PixelFormat.Format32bppPArgb))
                                                     using (var tmpG = Graphics.FromImage(tmpBuffer)) //temporary graphic object that can be messed up independently
                                                     {
                                                         var randomChar = ch[0].ToString();
-                                                        symbolWidth = tmpG.MeasureString(randomChar, font, 0, sf).Width;
+                                                        symbolWidth = TextRenderer.MeasureText(randomChar, Font).Width;
                                                         if (symbolWidth > 0) //don't draw when symbol width == 0 (symptom obtained from trial-n-error)
                                                         {
                                                             using (var brush = new SolidBrush(TextColor.GetColor(curForeColor)))
@@ -1057,6 +998,7 @@ namespace ZeroKLobby.MicroLobby
                                                                              startY,
                                                                              sf);
                                                             }
+                                                            TextRenderer.DrawText(g, randomChar, font, new Point((int)startX, startY), TextColor.GetColor(curForeColor));
                                                         }
                                                     }
                                                     startX += symbolWidth;
@@ -1104,28 +1046,13 @@ namespace ZeroKLobby.MicroLobby
                                                     //draw whats previously in the string                                
                                                     if (curBackColor != backColor)
                                                     {
-                                                        textSize = (int)g.MeasureString(buildString.ToString(), font, 0, sf).Width + 1;
+                                                        textSize = TextRenderer.MeasureText(buildString.ToString(), Font).Width + 1;
                                                         var r = new Rectangle((int)startX, startY, textSize + 1, LineSize + 1);
                                                         g.FillRectangle(backColorBrush, r); //draw black (or white) rectangle
                                                     }
-                                                    /* //GDI example:
-                                                        TextRenderer.DrawText(g,
-                                                                        buildString.ToString(),
-                                                                        font,
-                                                                        new Point((int)startX, startY),
-                                                                        TextColor.GetColor(curForeColor),
-                                                                        TextColor.GetColor(curBackColor));
-                                                    */
-                                                    using (var solidBrush = new SolidBrush(TextColor.GetColor(curForeColor))) {
-                                                        g.DrawString(buildString.ToString(), //draw text (that wasn't yet drawn up to *this* point)
-                                                                        font,
-                                                                        solidBrush,
-                                                                        startX,
-                                                                        startY,
-                                                                        sf);
-                                                    }
+                                                    TextRenderer.DrawText(g, buildString.ToString(), font, new Point((int)startX, startY), TextColor.GetColor(curForeColor));
 
-                                                    startX += g.MeasureString(buildString.ToString(), font, 0, sf).Width; //textSizes[32]
+                                                    startX += TextRenderer.MeasureText(buildString.ToString(), Font).Width; //textSizes[32]
 
                                                     buildString.Clear();//reset the content (because we already draw it for user)
 
@@ -1157,14 +1084,11 @@ namespace ZeroKLobby.MicroLobby
                             {
                                 if (curBackColor != backColor)
                                 {
-                                    textSize = (int)g.MeasureString(buildString.ToString(), font, 0, sf).Width + 1;
+                                    textSize = TextRenderer.MeasureText(buildString.ToString(), Font).Width + 1;
                                     var r = new Rectangle((int)startX, startY, textSize + 1, LineSize + 1);
                                     using (var brush = new SolidBrush(TextColor.GetColor(curBackColor))) g.FillRectangle(brush, r);
                                 }
-                                // TextRenderer.DrawText(g, buildString.ToString(), font, new Point((int)startX, startY), TextColor.GetColor(curForeColor), TextColor.GetColor(curBackColor));
-                                using (var brush = new SolidBrush(TextColor.GetColor(curForeColor))) {
-                                    g.DrawString(buildString.ToString(), font, brush, startX, startY, sf);
-                                }
+                                TextRenderer.DrawText(g, buildString.ToString(), font, new Point((int)startX, startY), TextColor.GetColor(curForeColor), TextColor.GetColor(curBackColor));
                             }
 
                             startY += LineSize;
@@ -1298,23 +1222,13 @@ namespace ZeroKLobby.MicroLobby
             {
                 if (lineNumber < TotalDisplayLines && lineNumber >= 0)
                 {
-                    var g = CreateGraphics();
-
-                    g.SmoothingMode = SmoothingMode.AntiAlias;
-                    g.TextRenderingHint = TextRenderingHint.AntiAlias;
-
-                    var sf = StringFormat.GenericTypographic;
-                    sf.FormatFlags |= StringFormatFlags.MeasureTrailingSpaces;
-
                     var lineEmot = displayLines[lineNumber].Line.StripAllCodesExceptEmot();
                     var line = displayLines[lineNumber].Line.StripAllCodes(); //get all character of the line (Note: StripAllCodes() is a function in TextColor.cs)
 
                     //do line-width check once if "x" is greater than line width, else check every character for the correct position where "x" is pointing at. 
-                    //int width = (int)g.MeasureString(line, Font, 0, sf).Width; //<-- you can uncomment this and comment the next line. The bad thing is: it underestimate end position if there's emotIcon, it cut some char during selection
-                    int width = (int)g.MeasureString(lineEmot, Font, 0, sf).Width;
+                    int width = TextRenderer.MeasureText(lineEmot, Font).Width;
                     if (x > width)
                     {
-                        g.Dispose();
                         return line.Length; //end of line
                     }
 
@@ -1331,15 +1245,13 @@ namespace ZeroKLobby.MicroLobby
                             i--; //halt pointer position for this time once (at second try the emot char will be gone, its size is added and continue checking the other stuff)
                             continue;
                         }
-                        float charWidth = g.MeasureString(line[i].ToString(), Font, 0, sf).Width;
+                        float charWidth = TextRenderer.MeasureText(line[i].ToString(), Font).Width;
                         lookWidth += charWidth;
                         if ((int)lookWidth >= (x + (int)charWidth / 2)) //check whether this character is on cursor position or not.  Note: char checking & x-coordinate is checked from left to right (everything is from left to right)
                         {
-                            g.Dispose();
                             return i;
                         }
                     }
-                    g.Dispose();
                     return line.Length;
                 }
             }
@@ -1357,27 +1269,18 @@ namespace ZeroKLobby.MicroLobby
             {
                 if (lineNumber < TotalDisplayLines && lineNumber >= 0)
                 {
-                    var g = CreateGraphics();
-                    g.SmoothingMode = SmoothingMode.AntiAlias;
-                    g.TextRenderingHint = TextRenderingHint.AntiAlias;
-
-                    var sf = StringFormat.GenericTypographic;
-                    sf.FormatFlags |= StringFormatFlags.MeasureTrailingSpaces;
-
                     var lineEmot = displayLines[lineNumber].Line.StripAllCodesExceptEmot();
                     var line = displayLines[lineNumber].Line.StripAllCodes();
 
                     //do line-width check once if "x" is greater than line width,
-                    int width = (int)g.MeasureString(line, Font, 0, sf).Width;
+                    int width = TextRenderer.MeasureText(line, Font).Width;
                     //int width = (int)g.MeasureString(lineEmot, Font, 0, sf).Width; / //<-- you can uncomment this and comment the previous line. The bad thing is: will overestimate hyperlinks ending, which make you able to click empty space
                     if (x > width)
                     {
-                        g.Dispose();
                         return "";
                     }
                     if (x <= 0)
                     {
-                        g.Dispose();
                         return "";
                     }
 
@@ -1402,11 +1305,9 @@ namespace ZeroKLobby.MicroLobby
                             {
                                 // this line wraps from the previous one. 
                                 var prevline = displayLines[lineNumber - 1].Line.StripAllCodes();
-                                int prevwidth = (int)g.MeasureString(prevline, Font, 0, sf).Width;
-                                g.Dispose();
+                                int prevwidth = TextRenderer.MeasureText(prevline, Font).Width;
                                 return ReturnWord(lineNumber - 1, prevwidth);
                             }
-                            g.Dispose();
                             return line.Substring(space, i - space); //Substring(space, i - space), in example: xxx__Yxxxx_T_xxx OR Yxx_T_xxxxx__xxx (where T is pointing at spaces, Y pointing at 1st letter)
                         }
 
@@ -1423,7 +1324,7 @@ namespace ZeroKLobby.MicroLobby
                             }
                         }
 
-                        lookWidth += g.MeasureString(line[i].ToString(), Font, 0, sf).Width;
+                        lookWidth += TextRenderer.MeasureText(line[i].ToString(), Font).Width;
                     }
                     if (displayLines[lineNumber].Previous && lineNumber > 0 && space == 0)
                     {
@@ -1431,8 +1332,7 @@ namespace ZeroKLobby.MicroLobby
                         var prevline = displayLines[lineNumber - 1].Line.StripAllCodes();
                         if (prevline[prevline.Length - 1] != ' ')
                         {
-                            int prevwidth = (int)g.MeasureString(prevline, Font, 0, sf).Width;
-                            g.Dispose();
+                            int prevwidth = TextRenderer.MeasureText(prevline, Font).Width;
                             return ReturnWord(lineNumber - 1, prevwidth);
                         }
                     }
@@ -1457,11 +1357,9 @@ namespace ZeroKLobby.MicroLobby
                                     break;
                                 }
                             }
-                            g.Dispose();
                             return line.Substring(space) + extra;
                         }
                     }
-                    g.Dispose();
                 }
             }
             catch (Exception ee)

--- a/ZeroKLobby/ToolTips/BattleTooltipRenderer.cs
+++ b/ZeroKLobby/ToolTips/BattleTooltipRenderer.cs
@@ -44,12 +44,13 @@ namespace ZeroKLobby
                     y += 16;
                 };
             Action<string> drawString = text =>
-            {
-                    y -= 3;
-                TextRenderer.DrawText(g, text, font, new Point(x, y), Config.TextColor);
-                x += TextRenderer.MeasureText(text, font).Width;
-                    y += 3;
-            };
+                {
+                    //y -= 3;
+                    x += ToolTipHandler.TEXT_X_OFFSET;
+                    TextRenderer.DrawText(g, text, font, new Point(x, y + ToolTipHandler.TEXT_Y_OFFSET), Config.TextColor, TextFormatFlags.LeftAndRightPadding);
+                    x += TextRenderer.MeasureText(g, text, font).Width;
+                    //y += 3;
+                };
             Action<Image, int, int> drawImage = (image, w, h) =>
                 {
                     g.DrawImage(image, x, y, w, h);

--- a/ZeroKLobby/ToolTips/BattleTooltipRenderer.cs
+++ b/ZeroKLobby/ToolTips/BattleTooltipRenderer.cs
@@ -46,8 +46,8 @@ namespace ZeroKLobby
             Action<string> drawString = text =>
             {
                     y -= 3;
-                    g.DrawString(text, font,fbrush, new Point(x, y));
-                    x += (int)Math.Ceiling((double)g.MeasureString(text, font).Width);
+                TextRenderer.DrawText(g, text, font, new Point(x, y), Config.TextColor);
+                x += TextRenderer.MeasureText(text, font).Width;
                     y += 3;
             };
             Action<Image, int, int> drawImage = (image, w, h) =>

--- a/ZeroKLobby/ToolTips/MapTooltipRenderer.cs
+++ b/ZeroKLobby/ToolTips/MapTooltipRenderer.cs
@@ -31,8 +31,9 @@ namespace ZeroKLobby
                 };
             Action<string> drawString = text =>
                 {
-                    TextRenderer.DrawText(g, text, font, new Point(x + 1, y), Config.TextColor);
-                    x += TextRenderer.MeasureText(text, font).Width;
+                    x += ToolTipHandler.TEXT_X_OFFSET;
+                    TextRenderer.DrawText(g, text, font, new Point(x + 1, y + ToolTipHandler.TEXT_Y_OFFSET), Config.TextColor, TextFormatFlags.LeftAndRightPadding);
+                    x += TextRenderer.MeasureText(g, text, font).Width;
                 };
             Action<Image, int, int> drawImage = (image, w, h) =>
                 {

--- a/ZeroKLobby/ToolTips/MapTooltipRenderer.cs
+++ b/ZeroKLobby/ToolTips/MapTooltipRenderer.cs
@@ -31,15 +31,15 @@ namespace ZeroKLobby
                 };
             Action<string> drawString = text =>
                 {
-                    g.DrawString(text, font, fbrush, new Point(x, y));
-                    x += (int)Math.Ceiling((double)g.MeasureString(text, font).Width);
+                    TextRenderer.DrawText(g, text, font, new Point(x + 1, y), Config.TextColor);
+                    x += TextRenderer.MeasureText(text, font).Width;
                 };
             Action<Image, int, int> drawImage = (image, w, h) =>
                 {
                     g.DrawImage(image, x, y, w, h);
                     x += w + 3;
                 };
-            using (var boldFont = new Font(font, FontStyle.Bold)) g.DrawString(Map.GetHumanName(mapName), boldFont, fbrush, new Point(x, y));
+            using (var boldFont = new Font(font, FontStyle.Bold)) TextRenderer.DrawText(g, Map.GetHumanName(mapName), boldFont, new Point(x + 1, y), Config.TextColor);
 
             if (map != null)
             {

--- a/ZeroKLobby/ToolTips/PlayerTooltipRenderer.cs
+++ b/ZeroKLobby/ToolTips/PlayerTooltipRenderer.cs
@@ -25,7 +25,7 @@ namespace ZeroKLobby
             User user;
             if (!Program.TasClient.ExistingUsers.TryGetValue(userName, out user)) return;
             var x = (int)1;
-            var y = 0;
+            var y = 3;
             Action newLine = () =>
                 {
                 x = (int)1;
@@ -33,18 +33,20 @@ namespace ZeroKLobby
                 };
             Action<string> drawString = (text) =>
             {
-                y -= 3;
-                TextRenderer.DrawText(g, text, font, new Point(x, y), Config.TextColor);
-                x += TextRenderer.MeasureText(text, font).Width;
-                y += 3;
+                //y -= 3;
+                x += ToolTipHandler.TEXT_X_OFFSET;
+                TextRenderer.DrawText(g, text, font, new Point(x, y + ToolTipHandler.TEXT_Y_OFFSET), Config.TextColor, TextFormatFlags.LeftAndRightPadding);
+                x += TextRenderer.MeasureText(g, text, font).Width;
+                //y += 3;
             };
             
             Action<string, Color> drawString2 = (text, color) =>
             {
-                y -= 3;
-                TextRenderer.DrawText(g, text, font, new Point(x, y), Config.TextColor);
-                x += TextRenderer.MeasureText(text, font).Width;
-                y += 3;
+                //y -= 3;
+                x += ToolTipHandler.TEXT_X_OFFSET;
+                TextRenderer.DrawText(g, text, font, new Point(x, y + ToolTipHandler.TEXT_Y_OFFSET), color, TextFormatFlags.LeftAndRightPadding);
+                x += TextRenderer.MeasureText(g, text, font).Width;
+                //y += 3;
             };
 
 
@@ -53,7 +55,7 @@ namespace ZeroKLobby
                     g.DrawImage(image, x, y, (int)w, (int)h);
                     x += (int)(w + 3);
                 };
-            using (var boldFont = new Font(font, FontStyle.Bold)) TextRenderer.DrawText(g, user.Name, boldFont, new Point(x, y), Config.TextColor);
+            using (var boldFont = new Font(font, FontStyle.Bold)) TextRenderer.DrawText(g, user.Name, boldFont, new Point(x, y), Config.TextColor, TextFormatFlags.LeftAndRightPadding);
             y += 3;
             newLine();
 

--- a/ZeroKLobby/ToolTips/PlayerTooltipRenderer.cs
+++ b/ZeroKLobby/ToolTips/PlayerTooltipRenderer.cs
@@ -34,18 +34,16 @@ namespace ZeroKLobby
             Action<string> drawString = (text) =>
             {
                 y -= 3;
-                    g.DrawString(text, font, fbrush, new Point(x, y));
-                    x += (int)Math.Ceiling(g.MeasureString(text, font).Width);
+                TextRenderer.DrawText(g, text, font, new Point(x, y), Config.TextColor);
+                x += TextRenderer.MeasureText(text, font).Width;
                 y += 3;
             };
             
             Action<string, Color> drawString2 = (text, color) =>
             {
                 y -= 3;
-                using (var brush = new SolidBrush(color)) {
-                    g.DrawString(text, font, brush, new Point(x, y));
-                }
-                x += (int)Math.Ceiling((double)g.MeasureString(text, font).Width);
+                TextRenderer.DrawText(g, text, font, new Point(x, y), Config.TextColor);
+                x += TextRenderer.MeasureText(text, font).Width;
                 y += 3;
             };
 
@@ -55,7 +53,7 @@ namespace ZeroKLobby
                     g.DrawImage(image, x, y, (int)w, (int)h);
                     x += (int)(w + 3);
                 };
-            using (var boldFont = new Font(font, FontStyle.Bold)) g.DrawString(user.Name, boldFont, fbrush, new Point(x, y));
+            using (var boldFont = new Font(font, FontStyle.Bold)) TextRenderer.DrawText(g, user.Name, boldFont, new Point(x, y), Config.TextColor);
             y += 3;
             newLine();
 

--- a/ZeroKLobby/ToolTips/ToolTipHandler.cs
+++ b/ZeroKLobby/ToolTips/ToolTipHandler.cs
@@ -25,6 +25,9 @@ namespace ZeroKLobby
         const Int32 SWP_NOSENDCHANGING = 0x0400;
         const Int32 SWP_ToolTipOption = SWP_NOACTIVATE | SWP_NOSIZE | SWP_ASYNCWINDOWPOS | SWP_NOCOPYBITS 
             | SWP_DEFERERASE | SWP_NOMOVE | SWP_NOREDRAW | SWP_NOSENDCHANGING; //disable all SetWindowPos() function except Z-ordering
+
+        public const int TEXT_Y_OFFSET = 6;
+        public const int TEXT_X_OFFSET = 3;
         private bool lastActive = true;
         private Point lastMousePos;
         private string lastText;


### PR DESCRIPTION
> Replace as many uses of graphics.MeasureString and graphics.drawString with TextRenderer.MeasureText and TextRenderer.DrawText as possible

Fixes #1108 
See http://stackoverflow.com/a/23230570 for more details

Side effect: Scrolling text window now has noticable delay, particularly when window height is large