### PR TITLE
Make guide urls in top navbar valid

### DIFF
--- a/Zero-K.info/Views/Shared/TopMenu.cshtml
+++ b/Zero-K.info/Views/Shared/TopMenu.cshtml
@@ -41,10 +41,10 @@
                   <li><a href="/mediawiki/index.php?title=Manual">Manual</a>
                       <ul>
                           <li><a href="/mediawiki/index.php?title=Manual">Index</a></li>
-                          <li><a href="/mediawiki/index.php?title=Newbie Guide">Newbie guide<span>Don't know where to begin? Click
+                          <li><a href="/mediawiki/index.php?title=Newbie_Guide">Newbie guide<span>Don't know where to begin? Click
                                                                           here.</span></a></li>
                           <li><a href="/Static/UnitGuide">Units</a></li>
-                          <li><a href="/mediawiki/index.php?title=Economy Guide">Economy</a></li>
+                          <li><a href="/mediawiki/index.php?title=Economy_Guide">Economy</a></li>
                           <li><a href="/mediawiki/index.php?title=Terraform">Terraforming<span>Let's go play in the dirt!</span></a></li>
                           <li><a href="/mediawiki/index.php?title=FAQ">FAQ<span>Frequently Asked Questions</span></a></li>
                       </ul>


### PR DESCRIPTION
Whitespace characters are illegal in URLs. I replace them with _ instead of + or %20 because the wiki pages themselves use _