### PR TITLE
Fix ZK logo height attribute

### DIFF
--- a/Zero-K.info/Views/Shared/_SiteLayout.cshtml
+++ b/Zero-K.info/Views/Shared/_SiteLayout.cshtml
@@ -62,7 +62,7 @@
         <div id="mainContentWrapper" class="wrapper">
             <div id="header" style="text-align:center">
                 <a href="/">
-                    <img src="/img/zk_logo.png" height="150px" alt="Zero K" />
+                    <img src="/img/zk_logo.png" height="150" alt="Zero K" />
                 </a>
             </div>
             <div class="border" id="menu" style="padding: 0">


### PR DESCRIPTION
HTML height attributes do not accept letters. "150px" would be valid in CSS, but not in HTML where it's px by default.

This change should stop the non-logo content of zero-k.info from jumping down while the page is being drawn by reserving space for the logo right from the start, even before the image completes loading.