### PR TITLE
Add alt text for search buttons

### DIFF
--- a/Zero-K.info/Views/Battles/BattleIndex.cshtml
+++ b/Zero-K.info/Views/Battles/BattleIndex.cshtml
@@ -16,7 +16,7 @@
     Age: @Html.EnumDropDownListFor(x => x.Age)
     Mission: @Html.EnumDropDownListFor(x => x.Mission)
     Bots: @Html.EnumDropDownListFor(x => x.Bots)
-    <input name="sa" value="Search" type="image" src="/img/search_img.png" style="border: none; vertical-align: middle;"/>
+    <input name="sa" value="Search" alt="Search" type="image" src="/img/search_img.png" style="border: none; vertical-align: middle;"/>
 </form>
 <table>
     <tr>

--- a/Zero-K.info/Views/Missions/Index.cshtml
+++ b/Zero-K.info/Views/Missions/Index.cshtml
@@ -20,7 +20,7 @@
     <label>
         <span title="Missions where players fight each other">@Html.CheckBox("adversarial", true) adversarial&nbsp;&nbsp;</span>
     </label>
-    Name or author: @Html.TextBox("search", Model.SearchString) <input name="sa" value="Search" type="image" src="/img/search_img.png" style="border: none; vertical-align: middle;" />
+    Name or author: @Html.TextBox("search", Model.SearchString) <input name="sa" value="Search" alt="Search" type="image" src="/img/search_img.png" style="border: none; vertical-align: middle;" />
 </form>
 
 <script type="text/javascript">

--- a/Zero-K.info/Views/Shared/SiteSearch.cshtml
+++ b/Zero-K.info/Views/Shared/SiteSearch.cshtml
@@ -1,6 +1,6 @@
 ﻿<form action="@Url.Action("SubmitSearch","Forum")" method="POST">
     <div>
         <input type="text" name="keywords" id="keywords" size="20" data-autocomplete="@Url.Action("Index", "Autocomplete")" data-autocomplete-action="goto"/>
-        <input value="Search" type="image" src="/img/search_img.png" style="border: none; vertical-align: middle;"/>
+        <input value="Search" alt="Search" type="image" src="/img/search_img.png" style="border: none; vertical-align: middle;"/>
     </div>
 </form>


### PR DESCRIPTION
Inputs of type image require an attribute for alternative text. This makes buttons usable when images are not loaded (eg. when disabling them to store bandwidth on mobile, or when the file gets lost for whatever reason).