### PR TITLE
Show "correct" (competitive) elo changes on battle stats page

### DIFF
--- a/ZkData/Ef/SpringBattle.cs
+++ b/ZkData/Ef/SpringBattle.cs
@@ -84,8 +84,8 @@ namespace ZkData
             }
             else
             {
-                if (IsMatchMaker) CalculateEloGeneric(x => x.EloMm, x => x.EloMmWeight, (x, v) => x.EloMm = v, (x, v) => x.EloMmWeight = v);
                 if (Duration > GlobalConst.MinDurationForElo) CalculateEloGeneric(x => x.Elo, x => x.EloWeight, (x, v) => x.Elo = v, (x, v) => x.EloWeight = v);
+                if (IsMatchMaker) CalculateEloGeneric(x => x.EloMm, x => x.EloMmWeight, (x, v) => x.EloMm = v, (x, v) => x.EloMmWeight = v);
             }
 
             if (Duration > GlobalConst.MinDurationForXP) ApplyXpChanges();


### PR DESCRIPTION
It was showing the casual elo changes on MM battle pages. If both elo changes are supposed to be displayed (for admins), player.EloChange needs to be replaced by a Dictionary with keys  for each elo type.