### PR TITLE
Site: GetUserIP() returns an IPv4 if present

### DIFF
--- a/Zero-K.info/Global.asax.cs
+++ b/Zero-K.info/Global.asax.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Web;
 using System.Web.Mvc;
 using System.Web.Optimization;
@@ -102,8 +103,11 @@ namespace ZeroKWeb
 
         private string GetUserIP()
         {
-            var ip = Context.Request.ServerVariables["REMOTE_ADDR"];
-            return ip;
+            string hostname = Context.Request.ServerVariables["REMOTE_HOST"];
+            IPAddress[] ipv4s = Array.FindAll(Dns.GetHostEntry(string.Empty).AddressList,
+                a => a.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork);
+            if (ipv4s.Length > 0) return ipv4s[0].ToString();
+            return Context.Request.ServerVariables["REMOTE_ADDR"];
         }
 
         private void MvcApplication_Error(object sender, EventArgs e)


### PR DESCRIPTION
This fixes a potential failure with site ban by IP, where it currently gets the IPv6 and tries to look for matching IPv4 bans.

(Alternatively lobby clients could be allowed to report IPv6 instead)