### PR TITLE
Fix chrome levelprogress

### DIFF
--- a/Zero-K.info/Styles/base.css
+++ b/Zero-K.info/Styles/base.css
@@ -118,7 +118,10 @@ ul {list-style-type: circle;}
 }
 
 .fleft{float: left;}
-.fright{float: right;}
+.fright{
+	float: right;
+	-webkit-margin-after: 0px;
+}
 .clearfloat{clear:both;}
 
 .center


### PR DESCRIPTION
Before:
![broken](https://i.imgur.com/dFOS2kJ.png)
After:
![fixed](https://i.imgur.com/PI2FUvv.png)

This is caused by the default stylesheet which this change overrides.