### PR TITLE
PW ingame defs: use unitname as table key

### DIFF
--- a/ZkLobbyServer/SpringieInterface/StartSetup.cs
+++ b/ZkLobbyServer/SpringieInterface/StartSetup.cs
@@ -255,7 +255,7 @@ namespace ZeroKWeb.SpringieInterface
                     foreach (
                         var s in planet.PlanetStructures.Where(x => x.StructureType != null && !string.IsNullOrEmpty(x.StructureType.IngameUnitName)))
                     {
-                        pwStructures.Add("s" + s.StructureTypeID,
+                        pwStructures.Add(s.StructureType.IngameUnitName,
                             new LuaTable
                             {
                                 { "unitname", s.StructureType.IngameUnitName },


### PR DESCRIPTION
The key is currently ignored by ingame. However all other unitdefs use unitname as the key so it would allow some simplification.