### PR TITLE
angle-quote nightwatch github spam, prevents embed

### DIFF
--- a/Zero-K.info/Controllers/GithubController.cs
+++ b/Zero-K.info/Controllers/GithubController.cs
@@ -40,12 +40,12 @@ namespace ZeroKWeb.Controllers
                     if (payload.action == "labeled")
                         break;
                     values = new [] {payload.repository.name ,payload.sender.login,  payload.action, payload.issue.title, payload.issue.html_url};
-                    text = string.Format("[{0}] {1} has {2} issue {3} {4}",values);
+                    text = string.Format("[{0}] {1} has {2} issue {3} <{4}>",values);
                     break;
 
                 case "pull_request":
                     values = new [] {payload.repository.name ,payload.sender.login,  payload.action, payload.number, payload.pull_request.title , payload.pull_request.html_url, payload.pull_request.body};
-                    text = string.Format("[{0}] {1} has {2} pull request #{3}: {4} ( {5} )\n{6}",values);
+                    text = string.Format("[{0}] {1} has {2} pull request #{3}: {4} <{5}>\n{6}",values);
                     break;
 
                 case "push":
@@ -54,7 +54,7 @@ namespace ZeroKWeb.Controllers
                     dynamic commits = payload.commits;
                     foreach (dynamic commit in commits)
                     {
-                        sb.AppendFormat("\n {0} ( {1} )", commit.message, commit.url);
+                        sb.AppendFormat("\n {0} <{1}>", commit.message, commit.url);
                         count++;
                     }
                     if (count > 0) text = $"[{payload.repository.name}] {payload.sender.login} has pushed {count} commits: {sb}";


### PR DESCRIPTION
Discord has a thing that makes urls embedded in angle brackets ( `<` `>`) not embeddable, but still clickable like normal links.

Inflicting this upon Nightwatch's github notifications will make #zkdev@Discord much more readable.