### PR TITLE
PM people when they get punished

### DIFF
--- a/Zero-K.info/Controllers/UsersController.cs
+++ b/Zero-K.info/Controllers/UsersController.cs
@@ -258,7 +258,7 @@ namespace ZeroKWeb.Controllers
 
                 Global.Server.GhostChanSay(GlobalConst.ModeratorChannel, string.Format("New penalty for {0} {1}  ", acc.Name, Url.Action("Detail", "Users", new { id = acc.AccountID }, "http")));
                 Global.Server.GhostChanSay(GlobalConst.ModeratorChannel, string.Format("Reason: {0} ", reason));
-                Global.Server.GhostPm(acc.Name, string.Format("You have been punished: {0}", reason));
+                Global.Server.GhostPm(acc.Name, string.Format("Your account has received moderator action: {0}", reason));
             }
             catch (Exception ex)
             {

--- a/Zero-K.info/Controllers/UsersController.cs
+++ b/Zero-K.info/Controllers/UsersController.cs
@@ -258,6 +258,7 @@ namespace ZeroKWeb.Controllers
 
                 Global.Server.GhostChanSay(GlobalConst.ModeratorChannel, string.Format("New penalty for {0} {1}  ", acc.Name, Url.Action("Detail", "Users", new { id = acc.AccountID }, "http")));
                 Global.Server.GhostChanSay(GlobalConst.ModeratorChannel, string.Format("Reason: {0} ", reason));
+                Global.Server.GhostPm(acc.Name, string.Format("You have been punished: {0}", reason));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This is useful to give people official warnings. If the punishment has no effect they might miss it completely. Currently they only see the punishment reason if they go to their user page.