### PR TITLE
consider ignoring username case on login

### DIFF
--- a/ZkLobbyServer/LoginChecker.cs
+++ b/ZkLobbyServer/LoginChecker.cs
@@ -68,7 +68,11 @@ namespace ZkLobbyServer
                     Account accBySteamID = null;
                     Account accByLogin = null;
                     if (info != null) accBySteamID = db.Accounts.Include(x => x.Clan).Include(x => x.Faction).FirstOrDefault(x => x.SteamID == info.steamid);
-                    if (!string.IsNullOrEmpty(login.Name)) accByLogin = db.Accounts.Include(x => x.Clan).Include(x => x.Faction).FirstOrDefault(x => x.Name == login.Name);
+                    if (!string.IsNullOrEmpty(login.Name))
+                    {
+                        string nameUpper = login.Name.ToUpper();
+                        accByLogin = db.Accounts.Include(x => x.Clan).Include(x => x.Faction).FirstOrDefault(x => x.Name == login.Name) ?? db.Accounts.Include(x => x.Clan).Include(x => x.Faction).FirstOrDefault(x => x.Name.ToUpper() == nameUpper);
+                    }
 
                     if (accBySteamID == null)
                     {


### PR DESCRIPTION
Misspelled usernames keep leading to confusion because it is expected for usernames to be case insensitive.