### PR TITLE
In case zenity is not installed, try default terminal and xterm.

### DIFF
--- a/SteamRoot/setup-zerok.sh
+++ b/SteamRoot/setup-zerok.sh
@@ -21,12 +21,12 @@ then
     altterm="/etc/alternatives/x-terminal-emulator"
     if [ -f "$altterm" ]
     then
-      $altterm -e "bash -c \"echo 'We need to install some deps. (y/n)?' ; read answer ; if [ \$answer == \"y\" ]; then ${pkx} ${pkgmanager} -y install mono-complete libsdl2-2.0-0 libopenal1 libcurl3 zenity libgdiplus sqlite3; fi\""
+      $altterm -e "bash -c \"echo 'Zero-K needs SDL2 and other dependencies to run. Check for dependencies now (y/n)?' ; read answer ; if [ \$answer == \"y\" ]; then ${pkx} ${pkgmanager} -y install mono-complete libsdl2-2.0-0 libopenal1 libcurl3 zenity libgdiplus sqlite3; fi\""
     else
       # Can we use xterm?
       which xterm; if [ $? = 0 ]
       then
-        xterm -e "bash -c 'echo \"We need to install some deps. (y/n)?\" ; read answer ; if [ \$answer == \"y\" ]; then ${pkx} ${pkgmanager} -y install mono-complete libsdl2-2.0-0 libopenal1 libcurl3 zenity libgdiplus sqlite3; fi'"
+        xterm -e "bash -c 'echo \"Zero-K needs SDL2 and other dependencies to run. Check for dependencies now (y/n)?\" ; read answer ; if [ \$answer == \"y\" ]; then ${pkx} ${pkgmanager} -y install mono-complete libsdl2-2.0-0 libopenal1 libcurl3 zenity libgdiplus sqlite3; fi'"
       fi
     fi
   fi

--- a/SteamRoot/setup-zerok.sh
+++ b/SteamRoot/setup-zerok.sh
@@ -6,11 +6,29 @@ pkgmanager=$( which apt-get )
 pkx=$( which pkexec )
 if [ -n "${pkgmanager}" -a -n "${pkx}" ]
 then
-  zenity --question --title "Install Dependencies" --text "Zero-K needs SDL2 and other dependencies to run.\nCheck for dependencies now?"
-  answer=$?
-  if [ $answer = 0 ]
+  # We know how to install packages on this system.
+  # Can we show a prompt using zenity?
+  which zenity; if [ $? = 0 ]
   then
-    ${pkx} ${pkgmanager} -y install mono-complete libsdl2-2.0-0 libopenal1 libcurl3 zenity libgdiplus sqlite3
+    zenity --question --title "Install Dependencies" --text "Zero-K needs SDL2 and other dependencies to run.\nCheck for dependencies now?"
+    answer=$?
+    if [ $answer = 0 ]
+    then
+      ${pkx} ${pkgmanager} -y install mono-complete libsdl2-2.0-0 libopenal1 libcurl3 zenity libgdiplus sqlite3
+    fi
+  else
+    # No zenity. Can we use the default terminal?
+    altterm="/etc/alternatives/x-terminal-emulator"
+    if [ -f "$altterm" ]
+    then
+      $altterm -e "bash -c \"echo 'We need to install some deps. (y/n)?' ; read answer ; if [ \$answer == \"y\" ]; then ${pkx} ${pkgmanager} -y install mono-complete libsdl2-2.0-0 libopenal1 libcurl3 zenity libgdiplus sqlite3; fi\""
+    else
+      # Can we use xterm?
+      which xterm; if [ $? = 0 ]
+      then
+        xterm -e "bash -c 'echo \"We need to install some deps. (y/n)?\" ; read answer ; if [ \$answer == \"y\" ]; then ${pkx} ${pkgmanager} -y install mono-complete libsdl2-2.0-0 libopenal1 libcurl3 zenity libgdiplus sqlite3; fi'"
+      fi
+    fi
   fi
 fi
 


### PR DESCRIPTION
Improves the Linux zero-k dependency installation by trying the default terminal and xterm to inform the user about the password prompt if zenity is not available.