### PR TITLE
add rank information to userprofile message

### DIFF
--- a/Shared/LobbyClient/Protocol/Messages.cs
+++ b/Shared/LobbyClient/Protocol/Messages.cs
@@ -802,6 +802,9 @@ namespace LobbyClient
         public int Level { get; set; }
         public string LevelUpRatio { get; set; }
 
+        public int Rank { get; set; }
+        public string RankUpRatio { get; set; }
+
         public int EffectiveElo { get; set; }
         public int EffectiveMmElo { get; set; }
         public int EffectivePwElo { get; set; }

--- a/ZkData/Ef/Account.cs
+++ b/ZkData/Ef/Account.cs
@@ -683,6 +683,8 @@ namespace ZkData
                 Kudos = KudosGained,
                 Level = Level,
                 LevelUpRatio = GetLevelUpRatio().ToString("F2"),
+                Rank = Rank,
+                RankUpRatio = Ranks.GetRankProgress(this).ToString("F2"),
                 PwBombers = GetBombersAvailable().ToString("F2"),
                 PwDropships = GetDropshipsAvailable().ToString("F2"),
                 PwMetal = GetMetalAvailable().ToString("F2"),


### PR DESCRIPTION
This should allow displaying rank information in the lobby. 

Instead of using rank names I'd suggest simply displaying the current and next rank icon.