### PR TITLE
Unowned structure production fix

### DIFF
--- a/ZkData/Ef/Galaxy.cs
+++ b/ZkData/Ef/Galaxy.cs
@@ -78,9 +78,20 @@ namespace ZkData
                 
                 var warps = structs.Where(x => x.StructureType.EffectWarpProduction > 0).Sum(x => x.StructureType.EffectWarpProduction) ?? 0;
                 grp.Key.ProduceWarps(warps);
-
             }
+            // structures without owning individual (or individual is somehow not in a faction)
+            foreach (var grp in Planets.SelectMany(x => x.PlanetStructures).Where(x => x.IsActive && (x.Account == null || x.Account.Faction == null)).GroupBy(x => x.Planet.Faction))
+            {
+                var structs = grp.ToList();
+                var drops = structs.Where(x => x.StructureType.EffectDropshipProduction > 0).Sum(x => x.StructureType.EffectDropshipProduction) ?? 0;
+                grp.Key.ProduceDropships(drops);
 
+                var bombers = structs.Where(x => x.StructureType.EffectBomberProduction > 0).Sum(x => x.StructureType.EffectBomberProduction) ?? 0;
+                grp.Key.ProduceBombers(bombers);
+
+                var warps = structs.Where(x => x.StructureType.EffectWarpProduction > 0).Sum(x => x.StructureType.EffectWarpProduction) ?? 0;
+                grp.Key.ProduceWarps(warps);
+            }
 
             // produce victory points
             foreach (var fac in Planets.Where(x => x.Faction != null).GroupBy(x => x.Faction))


### PR DESCRIPTION
Currently structures without an owning account (or any where the owner somehow left faction without abandoning the structures) do not produce any dropships, bombers or warp cores. This PR fixes that.