### PR TITLE
Install packages on first run

### DIFF
--- a/SteamRoot/Zero-K.sh
+++ b/SteamRoot/Zero-K.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 installdir=$( dirname "${0}" )
 cd "$installdir"
-export LD_LIBRARY_PATH=
-export LD_PRELOAD=
-DISPLAY=:1
-zenity --info --title "Done!" --text "Zeroblub\!" &&  touch blub2
 if [ -f "$installdir/installed.txt" ]
     then
     mono Zero-K.exe "$@"

--- a/SteamRoot/Zero-K.sh
+++ b/SteamRoot/Zero-K.sh
@@ -1,14 +1,20 @@
 #!/bin/sh
 installdir=$( dirname "${0}" )
 cd "$installdir"
-if [ -f "$installdir/Zero-K.exe" ]
+export LD_LIBRARY_PATH=
+export LD_PRELOAD=
+DISPLAY=:1
+zenity --info --title "Done!" --text "Zeroblub\!" &&  touch blub2
+if [ -f "$installdir/installed.txt" ]
     then
     mono Zero-K.exe "$@"
-    else
-    if [ -f "$installdir/setup-zerok.sh" ]
-        then
-        /bin/bash setup-zerok.sh "$@"
-        else
-        zenity --info --title "Error!" --text "Zero-K installation file was corrupted\! Please remove installation and redownload."
-    fi
-fi
+else
+    pkgmanager=$( which apt-get )
+    pkx=$( which pkexec )
+    notify-send "Zero-K is installing required packages, please wait.. "
+    sleep 1
+    notify-send "The game will launch once the installation is complete."
+    ${pkx} ${pkgmanager} -y install mono-complete libsdl2-2.0-0 libopenal1 libcurl3 zenity libgdiplus sqlite3 && touch installed.txt
+
+    mono Zero-K.exe "$@"
+fi 


### PR DESCRIPTION
Leaves `setup-zerok.sh` untouched, so it can be run manually by people who want to do it themselves.