### PR TITLE
Increase MM maximum expansion time to 3 minutes

### DIFF
--- a/ZkLobbyServer/MatchMaker/MatchMaker.PlayerEntry.cs
+++ b/ZkLobbyServer/MatchMaker/MatchMaker.PlayerEntry.cs
@@ -13,11 +13,11 @@ namespace ZkLobbyServer
             public bool InvitedToPlay;
             public bool LastReadyResponse;
 
-            public int EloWidth => (int)(100.0 + WaitRatio * 300.0);
+            public int EloWidth => (int)(50.0 + WaitRatio * 350.0);
             public int MinConsideredElo => LobbyUser.EffectiveMmElo;
             public int MaxConsideredElo => (int)(LobbyUser.EffectiveMmElo + (Math.Max(1500, LobbyUser.RawMmElo) - LobbyUser.EffectiveMmElo) * WaitRatio);
 
-            public double WaitRatio => Math.Max(0, Math.Min(1.0, DateTime.UtcNow.Subtract(JoinedTime).TotalSeconds / 60.0));
+            public double WaitRatio => Math.Max(0, Math.Min(1.0, DateTime.UtcNow.Subtract(JoinedTime).TotalSeconds / 180.0));
 
             public DateTime JoinedTime { get; private set; } = DateTime.UtcNow;
             public User LobbyUser { get; private set; }


### PR DESCRIPTION
I think 60 seconds was just set for testing originally? I like the fast matching, but with our increasing steam activity I feel we could make use of better quality matches.