### PR TITLE
make sure parties always make up the entire team.

### DIFF
--- a/ZkLobbyServer/MatchMaker/MatchMaker.PlayerEntry.cs
+++ b/ZkLobbyServer/MatchMaker/MatchMaker.PlayerEntry.cs
@@ -45,7 +45,7 @@ namespace ZkLobbyServer
                     for (var i = qt.MaxSize; i >= qt.MaxSize - (qt.MaxSize - qt.MinSize) * qtMaxWait; i--)
                         if (qt.Mode == AutohostMode.GameChickens || i % 2 == 0)
                         {
-                            if (Party == null || (qt.Mode == AutohostMode.GameChickens && Party.UserNames.Count<=i) || Party.UserNames.Count <= i / 2) ret.Add(new ProposedBattle(i, this, qt, qt.EloCutOffExponent, allPlayers));
+                            if (Party == null || (qt.Mode == AutohostMode.GameChickens && Party.UserNames.Count<=i) || Party.UserNames.Count == i / 2) ret.Add(new ProposedBattle(i, this, qt, qt.EloCutOffExponent, allPlayers));
                         }
                 }
                 return ret;


### PR DESCRIPTION
 this prevents parties from being split and being put with randoms. This is because many people asked for a way to have their party be the entire team.