### PR TITLE
Future-proofing for competitive modoptions

### DIFF
--- a/Shared/LobbyClient/Battle.cs
+++ b/Shared/LobbyClient/Battle.cs
@@ -119,7 +119,13 @@ namespace LobbyClient
             return $"{ModName} {MapName} ({NonSpectatorCount}+{SpectatorCount}/{MaxPlayers})";
         }
 
-
+        public void SetCompetitiveModoptions()
+        {
+            ModOptions["MinSpeed"] = "1";
+            ModOptions["MaxSpeed"] = "1";
+            ModOptions["mutespec"] = "mute";
+            ModOptions["mutelobby"] = "mute";
+        }
 
         public LobbyHostingContext GetContext()
         {

--- a/ZkLobbyServer/MatchMaker/MatchMakerBattle.cs
+++ b/ZkLobbyServer/MatchMaker/MatchMakerBattle.cs
@@ -26,11 +26,10 @@ namespace ZkLobbyServer
             
             if (ModOptions == null) ModOptions = new Dictionary<string, string>();
 
-            // hacky way to send some extra start setup data
-            if (bat.QueueType.Mode != AutohostMode.GameChickens) ModOptions["mutespec"] = "mute";
+            // proper way to send some extra start setup data
+            if (bat.QueueType.Mode != AutohostMode.GameChickens)
+                SetCompetitiveModoptions();
             ModOptions["MatchMakerType"] = bat.QueueType.Name;
-            ModOptions["MinSpeed"] = "1";
-            ModOptions["MaxSpeed"] = "1";
 
             ValidateAndFillDetails();
         }

--- a/ZkLobbyServer/MatchMaker/PlanetWarsServerBattle.cs
+++ b/ZkLobbyServer/MatchMaker/PlanetWarsServerBattle.cs
@@ -29,7 +29,7 @@ namespace ZkLobbyServer
 
             if (ModOptions == null) ModOptions = new Dictionary<string, string>();
 
-            ModOptions["mutespec"] = "mute";
+            SetCompetitiveModoptions();
 
             ValidateAndFillDetails();
         }

--- a/ZkLobbyServer/MatchMaker/TourneyBattle.cs
+++ b/ZkLobbyServer/MatchMaker/TourneyBattle.cs
@@ -31,9 +31,9 @@ namespace ZkLobbyServer {
             Mode = prototype.TeamPlayers.Max(x => x.Count) == 1 ? AutohostMode.Game1v1 : AutohostMode.None;
             MaxPlayers = prototype.TeamPlayers.Sum(x=>x.Count);
             ModOptions = prototype.ModOptions;
-            ModOptions["mutespec"] = "mute";
-            ModOptions["mutelobby"] = "mute";
-            ModOptions["allyreclaim"] = "1";
+
+            SetCompetitiveModoptions();
+            ModOptions["allyreclaim"] = "1"; // even more competitive than the above
 
             ValidateAndFillDetails();
         }

--- a/ZkLobbyServer/SpringieInterface/StartSetup.cs
+++ b/ZkLobbyServer/SpringieInterface/StartSetup.cs
@@ -69,10 +69,6 @@ namespace ZeroKWeb.SpringieInterface
 
                     if (attacker == defender) defender = null;
 
-                    ret.ModOptions["MinSpeed"] = "1";
-                    ret.ModOptions["MaxSpeed"] = "1";
-                    ret.ModOptions["mutespec"] = "mute";
-
                     ret.ModOptions["attackingFaction"] = attacker.Shortcut;
                     ret.ModOptions["attackingFactionName"] = attacker.Name;
                     ret.ModOptions["attackingFactionColor"] = attacker.Color;


### PR DESCRIPTION
They were scattered all over the place. Some were missing so this patch also fixes that:
 * tourney rooms lacked the speed caps.
 * all other room types except tourney lacked mutelobby.