### PR TITLE
Added autohosts

### DIFF
--- a/Shared/LobbyClient/Battle.cs
+++ b/Shared/LobbyClient/Battle.cs
@@ -50,6 +50,10 @@ namespace LobbyClient
 
         public ConcurrentDictionary<string, UserBattleStatus> Users { get; set; }
 
+        public int MaxElo { get; protected set; } = int.MaxValue;
+        public int MinElo { get; protected set; } = int.MinValue;
+        public int MaxLevel { get; protected set; } = int.MaxValue;
+        public int MinLevel { get; protected set; } = int.MinValue;
 
         public Battle()
         {

--- a/ZkLobbyServer/ConnectedUser.cs
+++ b/ZkLobbyServer/ConnectedUser.cs
@@ -423,8 +423,7 @@ namespace ZkLobbyServer
                 if (bat.Users.TryGetValue(status.Name, out ubs))
                 {
                     // enfoce player count limit
-                    if ((status.IsSpectator == false) && (bat.Users[status.Name].IsSpectator == true) &&
-                        (bat.Users.Values.Count(x => !x.IsSpectator) >= bat.MaxPlayers)) status.IsSpectator = true;
+                    if (status.IsSpectator == false && !bat.CanUserPlay(this)) status.IsSpectator = true;
 
                     ubs.UpdateWith(status);
                     bat.ValidateBattleStatus(ubs);

--- a/ZkLobbyServer/ServerBattle.cs
+++ b/ZkLobbyServer/ServerBattle.cs
@@ -51,9 +51,14 @@ namespace ZkLobbyServer
         public DedicatedServer spring;
         public string battleInstanceGuid;
 
-        public MapSupportLevel MinimalMapSupportLevel => IsPassworded ? MapSupportLevel.None : MapSupportLevel.Supported;
+        public MapSupportLevel MinimalMapSupportLevel => IsAutohost ? MinimalMapSupportLevelAutohost : (IsPassworded ? MapSupportLevel.None : MapSupportLevel.Supported);
 
         public CommandPoll ActivePoll { get; private set; }
+
+        public bool IsAutohost { get; private set; }
+
+        public MapSupportLevel MinimalMapSupportLevelAutohost { get; protected set; } = MapSupportLevel.Featured;
+        
 
         static ServerBattle()
         {
@@ -152,9 +157,23 @@ namespace ZkLobbyServer
 
         public virtual async Task CheckCloseBattle()
         {
-            if (Users.IsEmpty && !spring.IsRunning)
+            if (Users.IsEmpty && !spring.IsRunning && !IsAutohost)
             {
                 await server.RemoveBattle(this);
+            }
+        }
+
+        public void SwitchAutohost(bool autohost, string founder)
+        {
+            if (autohost)
+            {
+                IsAutohost = true;
+                FounderName = "Autohost #" + BattleID;
+            }
+            else
+            {
+                IsAutohost = false;
+                FounderName = founder;
             }
         }
 
@@ -428,6 +447,16 @@ namespace ZkLobbyServer
             return true;
         }
 
+        public bool CanUserPlay(ConnectedUser connectedUser)
+        {
+            if (Users.Values.Count(x => !x.IsSpectator) >= MaxPlayers) return false;
+            if (connectedUser.User.EffectiveElo > MaxElo) return false;
+            if (connectedUser.User.EffectiveElo < MinElo) return false;
+            if (connectedUser.User.Level > MaxLevel) return false;
+            if (connectedUser.User.Level < MinLevel) return false;
+
+            return true;
+        }
 
         public async Task StartVote(BattleCommand command, Say e, string args)
         {
@@ -496,6 +525,31 @@ namespace ZkLobbyServer
             await
                 server.Broadcast(server.ConnectedUsers.Values,
                     new BattleUpdate() { Header = new BattleHeader() { BattleID = BattleID, MaxPlayers = MaxPlayers } });
+        }
+
+        public async Task SwitchMaxElo(int elo)
+        {
+            MaxElo = elo;
+        }
+
+        public async Task SwitchMinElo(int elo)
+        {
+            MinElo = elo;
+        }
+
+        public async Task SwitchMaxLevel(int lvl)
+        {
+            MaxLevel = lvl;
+        }
+
+        public async Task SwitchMinLevel(int lvl)
+        {
+            MinLevel = lvl;
+        }
+
+        public async Task SwitchMinMapSupportLevel(MapSupportLevel lvl)
+        {
+            MinimalMapSupportLevelAutohost = lvl;
         }
 
         public async Task SwitchPassword(string pwd)
@@ -619,6 +673,7 @@ namespace ZkLobbyServer
                     });
 
             toNotify.Clear();
+            if (IsAutohost) RunCommandDirectly<CmdMap>(null);
             await CheckCloseBattle();
         }
 

--- a/ZkLobbyServer/ZkLobbyServer.csproj
+++ b/ZkLobbyServer/ZkLobbyServer.csproj
@@ -112,6 +112,7 @@
     <Compile Include="autohost\Commands\CmdBalance.cs" />
     <Compile Include="autohost\Commands\CmdCheats.cs" />
     <Compile Include="autohost\Commands\CmdEndvote.cs" />
+    <Compile Include="autohost\Commands\CmdAutohost.cs" />
     <Compile Include="autohost\Commands\CmdEngine.cs" />
     <Compile Include="autohost\Commands\CmdExit.cs" />
     <Compile Include="autohost\Commands\CmdForce.cs" />
@@ -125,6 +126,11 @@
     <Compile Include="autohost\Commands\CmdGame.cs" />
     <Compile Include="autohost\Commands\CmdListOptions.cs" />
     <Compile Include="autohost\Commands\CmdMap.cs" />
+    <Compile Include="autohost\Commands\CmdMinElo.cs" />
+    <Compile Include="autohost\Commands\CmdMinMapSupportLevel.cs" />
+    <Compile Include="autohost\Commands\CmdMinLevel.cs" />
+    <Compile Include="autohost\Commands\CmdMaxLevel.cs" />
+    <Compile Include="autohost\Commands\CmdMaxElo.cs" />
     <Compile Include="autohost\Commands\CmdMaxPlayers.cs" />
     <Compile Include="autohost\Commands\CmdN.cs" />
     <Compile Include="autohost\Commands\CmdNotify.cs" />

--- a/ZkLobbyServer/autohost/Commands/BattleCommand.cs
+++ b/ZkLobbyServer/autohost/Commands/BattleCommand.cs
@@ -120,6 +120,8 @@ namespace ZkLobbyServer
                 count = battle.Users.Count(x => !x.Value.IsSpectator);
             }
 
+            if (Access == AccessType.Admin && hasAdminRights) return RunPermission.Run;
+
             var defPerm = hasAdminRights ? RunPermission.Run : (isSpectator || isAway ? RunPermission.None : RunPermission.Vote);
 
             if (defPerm == RunPermission.None)
@@ -144,7 +146,12 @@ namespace ZkLobbyServer
                     return RunPermission.None;
                 }
             }
-            if (Access == AccessType.NotIngame)
+            if (Access == AccessType.NotIngameNotAutohost && battle.IsAutohost && !hasAdminRights)
+            {
+                reason = "This command cannot be used on autohosts, either ask a moderator to change the settings or create your own host.";
+                return RunPermission.None;
+            }
+            if (Access == AccessType.NotIngame || Access == AccessType.NotIngameNotAutohost)
             {
                 if (!s.IsRunning)
                 {
@@ -189,6 +196,18 @@ namespace ZkLobbyServer
             /// </summary>
             [Description("When game running, by players, needs vote")]
             IngameVote = 4,
+
+            /// <summary>
+            /// Can be executed ingame/offgame by admins only
+            /// </summary>
+            [Description("At any time, by admins only, no vote needed")]
+            Admin = 5,
+
+            /// <summary>
+            /// Can be executed not-ingame by non-spectators (vote) or admins or founder (direct). Unavailable to non-admins on autohosts
+            /// </summary>
+            [Description("When game not running, by players, might need a vote")]
+            NotIngameNotAutohost = 6,
         }
 
 

--- a/ZkLobbyServer/autohost/Commands/BattleCommand.cs
+++ b/ZkLobbyServer/autohost/Commands/BattleCommand.cs
@@ -105,7 +105,8 @@ namespace ZkLobbyServer
                 }
             }
 
-            var hasAdminRights = userName == battle.FounderName || user?.IsAdmin == true;
+            var hasAdminRights = user?.IsAdmin == true;
+            var hasElevatedRights = hasAdminRights || userName == battle.FounderName;
 
             var s = battle.spring;
             bool isSpectator = IsSpectator(battle, userName, ubs);
@@ -122,7 +123,7 @@ namespace ZkLobbyServer
 
             if (Access == AccessType.Admin && hasAdminRights) return RunPermission.Run;
 
-            var defPerm = hasAdminRights ? RunPermission.Run : (isSpectator || isAway ? RunPermission.None : RunPermission.Vote);
+            var defPerm = hasElevatedRights ? RunPermission.Run : (isSpectator || isAway ? RunPermission.None : RunPermission.Vote);
 
             if (defPerm == RunPermission.None)
             {

--- a/ZkLobbyServer/autohost/Commands/CmdAutohost.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdAutohost.cs
@@ -19,9 +19,9 @@ namespace ZkLobbyServer
 
         public override string Arm(ServerBattle battle, Say e, string arguments = null)
         {
-            if (battle.IsMatchMakerBattle)
+            if (battle.IsMatchMakerBattle || battle.ApplicableRating != RatingCategory.Casual)
             {
-                battle.Respond(e, "MatchMaker battles can't be repurposed as autohosts");
+                battle.Respond(e, "Only casual battles be repurposed as autohosts");
                 return null;
             }
             return string.Empty;

--- a/ZkLobbyServer/autohost/Commands/CmdAutohost.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdAutohost.cs
@@ -1,0 +1,36 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using LobbyClient;
+using PlasmaDownloader;
+using PlasmaShared;
+using ZeroKWeb.SpringieInterface;
+using ZkData;
+
+namespace ZkLobbyServer
+{
+    public class CmdAutohost : BattleCommand
+    {
+        private string engine;
+        public override string Help => "changes this host into an autohost or sets you as founder";
+        public override string Shortcut => "autohost";
+        public override AccessType Access => AccessType.Admin;
+
+        public override BattleCommand Create() => new CmdAutohost();
+
+        public override string Arm(ServerBattle battle, Say e, string arguments = null)
+        {
+            if (battle.IsMatchMakerBattle)
+            {
+                battle.Respond(e, "MatchMaker battles can't be repurposed as autohosts");
+                return null;
+            }
+            return string.Empty;
+        }
+
+
+        public override async Task ExecuteArmed(ServerBattle battle, Say e)
+        {
+            battle.SwitchAutohost(!battle.IsAutohost, e?.User);
+        }
+    }
+}

--- a/ZkLobbyServer/autohost/Commands/CmdMap.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdMap.cs
@@ -28,7 +28,14 @@ namespace ZkLobbyServer
                 var unsupportedMap = MapPicker.FindResources(ResourceType.Map, arguments, MapSupportLevel.None).FirstOrDefault();
                 if (unsupportedMap != null)
                 {
-                    battle.Respond(e, $"The map {unsupportedMap.InternalName} {GlobalConst.BaseSiteUrl}/Maps/Detail/{unsupportedMap.ResourceID} is not supported. Unsupported maps can only be played on passworded hosts.");
+                    if (battle.IsAutohost)
+                    {
+                        battle.Respond(e, $"The map {unsupportedMap.InternalName} {GlobalConst.BaseSiteUrl}/Maps/Detail/{unsupportedMap.ResourceID} is not available on this autohost. Play it in a player hosted battle.");
+                    }
+                    else
+                    {
+                        battle.Respond(e, $"The map {unsupportedMap.InternalName} {GlobalConst.BaseSiteUrl}/Maps/Detail/{unsupportedMap.ResourceID} is not supported. Unsupported maps can only be played on passworded hosts.");
+                    }
                 }
                 else
                 {

--- a/ZkLobbyServer/autohost/Commands/CmdMaxElo.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdMaxElo.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+using LobbyClient;
+using ZkData;
+
+namespace ZkLobbyServer
+{
+    public class CmdMaxElo : BattleCommand
+    {
+        private int elo;
+        public override string Help => "elo - changes elo limit for players, e.g. !maxelo 1600";
+        public override string Shortcut => "maxelo";
+        public override AccessType Access => AccessType.Admin;
+
+        public override BattleCommand Create() => new CmdMaxElo();
+
+        public override string Arm(ServerBattle battle, Say e, string arguments = null)
+        {
+            if (int.TryParse(arguments, out elo))
+            {
+                return string.Empty;
+            }
+            else return null;
+        }
+
+
+        public override async Task ExecuteArmed(ServerBattle battle, Say e)
+        {
+            await battle.SwitchMaxElo(elo);
+            await battle.SayBattle("Max elo changed to " + elo);
+
+        }
+    }
+}

--- a/ZkLobbyServer/autohost/Commands/CmdMaxLevel.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdMaxLevel.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+using LobbyClient;
+using ZkData;
+
+namespace ZkLobbyServer
+{
+    public class CmdMaxLevel : BattleCommand
+    {
+        private int lvl;
+        public override string Help => "level - changes level limit for players, e.g. !maxlevel 50";
+        public override string Shortcut => "maxlevel";
+        public override AccessType Access => AccessType.Admin;
+
+        public override BattleCommand Create() => new CmdMaxLevel();
+
+        public override string Arm(ServerBattle battle, Say e, string arguments = null)
+        {
+            if (int.TryParse(arguments, out lvl))
+            {
+                return string.Empty;
+            }
+            else return null;
+        }
+
+
+        public override async Task ExecuteArmed(ServerBattle battle, Say e)
+        {
+            await battle.SwitchMaxLevel(lvl);
+            await battle.SayBattle("Max level changed to " + lvl);
+
+        }
+    }
+}

--- a/ZkLobbyServer/autohost/Commands/CmdMaxPlayers.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdMaxPlayers.cs
@@ -9,7 +9,7 @@ namespace ZkLobbyServer
         private int cnt;
         public override string Help => "count - changes room size, e.g. !maxplayers 10";
         public override string Shortcut => "maxplayers";
-        public override AccessType Access => AccessType.NotIngame;
+        public override AccessType Access => AccessType.NotIngameNotAutohost;
 
         public override BattleCommand Create() => new CmdMaxPlayers();
 

--- a/ZkLobbyServer/autohost/Commands/CmdMinElo.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdMinElo.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+using LobbyClient;
+using ZkData;
+
+namespace ZkLobbyServer
+{
+    public class CmdMinElo : BattleCommand
+    {
+        private int elo;
+        public override string Help => "elo - changes elo limit for players, e.g. !minelo 1600";
+        public override string Shortcut => "minelo";
+        public override AccessType Access => AccessType.Admin;
+
+        public override BattleCommand Create() => new CmdMinElo();
+
+        public override string Arm(ServerBattle battle, Say e, string arguments = null)
+        {
+            if (int.TryParse(arguments, out elo))
+            {
+                return string.Empty;
+            }
+            else return null;
+        }
+
+
+        public override async Task ExecuteArmed(ServerBattle battle, Say e)
+        {
+            await battle.SwitchMinElo(elo);
+            await battle.SayBattle("Min Elo changed to " + elo);
+
+        }
+    }
+}

--- a/ZkLobbyServer/autohost/Commands/CmdMinLevel.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdMinLevel.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+using LobbyClient;
+using ZkData;
+
+namespace ZkLobbyServer
+{
+    public class CmdMinLevel : BattleCommand
+    {
+        private int lvl;
+        public override string Help => "level - changes level limit for players, e.g. !minlevel 50";
+        public override string Shortcut => "minlevel";
+        public override AccessType Access => AccessType.Admin;
+
+        public override BattleCommand Create() => new CmdMinLevel();
+
+        public override string Arm(ServerBattle battle, Say e, string arguments = null)
+        {
+            if (int.TryParse(arguments, out lvl))
+            {
+                return string.Empty;
+            }
+            else return null;
+        }
+
+
+        public override async Task ExecuteArmed(ServerBattle battle, Say e)
+        {
+            await battle.SwitchMinLevel(lvl);
+            await battle.SayBattle("Min level changed to " + lvl);
+
+        }
+    }
+}

--- a/ZkLobbyServer/autohost/Commands/CmdMinMapSupportLevel.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdMinMapSupportLevel.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading.Tasks;
+using LobbyClient;
+using ZkData;
+
+namespace ZkLobbyServer
+{
+    public class CmdMinMapSupportLevel : BattleCommand
+    {
+        private int level;
+        public override string Help => "level - changes minimum map support level (0-3), only for autohosts";
+        public override string Shortcut => "minmapsupportlevel";
+        public override AccessType Access => AccessType.Admin;
+
+        public override BattleCommand Create() => new CmdMinMapSupportLevel();
+
+        public override string Arm(ServerBattle battle, Say e, string arguments = null)
+        {
+            if (int.TryParse(arguments, out level))
+            {
+                return string.Empty;
+            }
+            else return null;
+        }
+
+
+        public override async Task ExecuteArmed(ServerBattle battle, Say e)
+        {
+            if (Enum.IsDefined(typeof(MapSupportLevel), level)) {
+                await battle.SwitchMinMapSupportLevel(((MapSupportLevel)level));
+                await battle.SayBattle("Minimum map support level changed to " + ((MapSupportLevel)level).ToString());
+            }
+
+        }
+    }
+}

--- a/ZkLobbyServer/autohost/Commands/CmdPassword.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdPassword.cs
@@ -10,7 +10,7 @@ namespace ZkLobbyServer
         private string pwd;
         public override string Help => "<newpassword> - sets room password";
         public override string Shortcut => "password";
-        public override AccessType Access => AccessType.NotIngame;
+        public override AccessType Access => AccessType.NotIngameNotAutohost;
 
         public override BattleCommand Create() => new CmdPassword();
 

--- a/ZkLobbyServer/autohost/Commands/CmdResetOptions.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdResetOptions.cs
@@ -8,7 +8,7 @@ namespace ZkLobbyServer
     {
         public override string Help => "sets default game/map options";
         public override string Shortcut => "resetoptions";
-        public override AccessType Access => AccessType.NotIngame;
+        public override AccessType Access => AccessType.NotIngameNotAutohost;
 
         public override BattleCommand Create() => new CmdResetOptions();
 

--- a/ZkLobbyServer/autohost/Commands/CmdSetOptions.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdSetOptions.cs
@@ -13,7 +13,7 @@ namespace ZkLobbyServer
         private string optionsAsString;
         public override string Help => "<name>=<value>[,<name>=<value>] - applies game/map options";
         public override string Shortcut => "setoptions";
-        public override AccessType Access => AccessType.NotIngame;
+        public override AccessType Access => AccessType.NotIngameNotAutohost;
 
         public override BattleCommand Create() => new CmdSetOptions();
 

--- a/ZkLobbyServer/autohost/Commands/CmdTitle.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdTitle.cs
@@ -10,7 +10,7 @@ namespace ZkLobbyServer
         private string title;
         public override string Help => "[title] - changes room title, e.g. !title All Welcome";
         public override string Shortcut => "title";
-        public override AccessType Access => AccessType.NotIngame;
+        public override AccessType Access => AccessType.NotIngameNotAutohost;
 
         public override BattleCommand Create() => new CmdTitle();
 

--- a/ZkLobbyServer/autohost/Commands/CmdType.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdType.cs
@@ -13,7 +13,7 @@ namespace ZkLobbyServer
         AutohostMode mode = AutohostMode.None;
         public override string Help => $"[type] - changes room type, e.g. !type custom ({string.Join(", ", GetValidTypes().Select(x => x.Description()))})";
         public override string Shortcut => "type";
-        public override AccessType Access => AccessType.NotIngame;
+        public override AccessType Access => AccessType.NotIngameNotAutohost;
 
         private static List<AutohostMode> GetValidTypes() => Enum.GetValues(typeof(AutohostMode)).Cast<AutohostMode>().Where(x => x != AutohostMode.Planetwars).ToList();
 


### PR DESCRIPTION
Autohosts can be created by an admin by calling !autohost in an existing room.
Autohosts have a fixed title, player limit, password and modoptions.
Autohosts change the map to a random featured map after each battle.
Additionally they can be customized using five new commands:
!maxelo, !minelo, !maxlevel, !minlevel, !minmapsupportlevel