### PR TITLE
Extra comms: handle N vs 2N+X case

### DIFF
--- a/ZkLobbyServer/SpringieInterface/StartSetup.cs
+++ b/ZkLobbyServer/SpringieInterface/StartSetup.cs
@@ -165,7 +165,7 @@ namespace ZeroKWeb.SpringieInterface
                                 userParams["pwInstructions"] = Convert.ToBase64String(Encoding.UTF8.GetBytes(GetPwInstructions(planet, user, db, attacker)));
                             }
 
-                            if (accountIDsWithExtraComms.Contains(user.AccountID)) userParams["extracomm"] = accountIDsWithExtraComms[user.accountID].ToString();
+                            if (accountIDsWithExtraComms.Contains(user.AccountID)) userParams["extracomm"] = accountIDsWithExtraComms[user.AccountID].ToString();
 
                             var commProfileIDs = new LuaTable();
                             var userCommandersBanned = Punishment.GetActivePunishment(user.AccountID, null, null, x => x.BanCommanders) != null; 

--- a/ZkLobbyServer/SpringieInterface/StartSetup.cs
+++ b/ZkLobbyServer/SpringieInterface/StartSetup.cs
@@ -40,10 +40,14 @@ namespace ZeroKWeb.SpringieInterface
                             var cnt = biggest.Count() - other.Count();
                             if (cnt > 0)
                             {
-                                foreach (var a in
-                                    other.Select(x => db.Accounts.First(y => y.AccountID == x.LobbyID))
-                                        .OrderByDescending(x => x.GetRating(RatingCategory.Casual).Elo)
-                                        .Take(cnt)) accountIDsWithExtraComms.Add(a.AccountID);
+                                int per_player = cnt / other.Count();
+                                cnt = cnt % other.Count();
+                                foreach (var a in other
+                                    .Select(x => db.Accounts.First(y => y.AccountID == x.LobbyID))
+                                    .OrderByDescending(x => x.GetRating(RatingCategory.Casual).Elo)) {
+                                        accountIDsWithExtraComms.Add(a.AccountID, per_player + (cnt > 0 ? 1 : 0));
+                                        cnt--;
+                                }
                             }
                         }
                     }
@@ -161,7 +165,7 @@ namespace ZeroKWeb.SpringieInterface
                                 userParams["pwInstructions"] = Convert.ToBase64String(Encoding.UTF8.GetBytes(GetPwInstructions(planet, user, db, attacker)));
                             }
 
-                            if (accountIDsWithExtraComms.Contains(user.AccountID)) userParams["extracomm"] = "1";
+                            if (accountIDsWithExtraComms.Contains(user.AccountID)) userParams["extracomm"] = accountIDsWithExtraComms[user.accountID].ToString();
 
                             var commProfileIDs = new LuaTable();
                             var userCommandersBanned = Punishment.GetActivePunishment(user.AccountID, null, null, x => x.BanCommanders) != null; 

--- a/ZkLobbyServer/SpringieInterface/StartSetup.cs
+++ b/ZkLobbyServer/SpringieInterface/StartSetup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data.Entity;
 using System.Diagnostics;
@@ -24,11 +24,11 @@ namespace ZeroKWeb.SpringieInterface
             {
                 var mode = context.Mode;
 
-               var commProfiles = new LuaTable();
+                var commProfiles = new LuaTable();
                 var db = new ZkDataContext();
 
                 // calculate to whom to send extra comms
-                var accountIDsWithExtraComms = new List<int>();
+                var accountIDsWithExtraComms = new Dictionary<int, int>();
                 if (mode == AutohostMode.Planetwars || mode == AutohostMode.GameFFA || mode == AutohostMode.Teams)
                 {
                     var groupedByTeam = context.Players.Where(x => !x.IsSpectator).GroupBy(x => x.AllyID).OrderByDescending(x => x.Count());
@@ -40,13 +40,22 @@ namespace ZeroKWeb.SpringieInterface
                             var cnt = biggest.Count() - other.Count();
                             if (cnt > 0)
                             {
+                                // example case: 3 players on this team, 8 players on largest team
+                                // 5 bonus comms to dole out to this team
+                                // per_player = 1 (integer result of 5/3)
+                                // remainder: 2, so now cnt = 2
+                                // iterate over all players in this team
+                                //  first player: cnt == 2, >0 so we give him a second extra comm
+                                //  second player: cnt == 1, >0 so same deal
+                                //  from now on cnt <= 0 so the remaining 3 players only get the one extra comm
                                 int per_player = cnt / other.Count();
                                 cnt = cnt % other.Count();
                                 foreach (var a in other
                                     .Select(x => db.Accounts.First(y => y.AccountID == x.LobbyID))
-                                    .OrderByDescending(x => x.GetRating(RatingCategory.Casual).Elo)) {
-                                        accountIDsWithExtraComms.Add(a.AccountID, per_player + (cnt > 0 ? 1 : 0));
-                                        cnt--;
+                                    .OrderByDescending(x => x.GetRating(RatingCategory.Casual).Elo))
+                                {
+                                    accountIDsWithExtraComms.Add(a.AccountID, per_player + (cnt > 0 ? 1 : 0));
+                                    cnt--;
                                 }
                             }
                         }
@@ -104,7 +113,7 @@ namespace ZeroKWeb.SpringieInterface
                 // write player custom keys (level, elo, is muted, etc.)
                 foreach (var p in context.Players)
                 {
-                    var user = db.Accounts.Where(x=>x.AccountID == p.LobbyID).Include(x=>x.RelalationsByOwner).FirstOrDefault();
+                    var user = db.Accounts.Where(x => x.AccountID == p.LobbyID).Include(x => x.RelalationsByOwner).FirstOrDefault();
                     if (user != null)
                     {
                         var userParams = new Dictionary<string, string>();
@@ -129,7 +138,7 @@ namespace ZeroKWeb.SpringieInterface
                             .Where(x => x.GetRating(context.ApplicableRating).Elo > user.GetRating(context.ApplicableRating).Elo)
                             .Count()
                             .ToString();
-                        
+
                         userParams["icon"] = user.GetIconName();
                         userParams["avatar"] = user.Avatar;
                         userParams["badges"] = string.Join(",", user.GetBadges());
@@ -140,9 +149,9 @@ namespace ZeroKWeb.SpringieInterface
                         var userSpecChatBlocked = Punishment.GetActivePunishment(user.AccountID, null, null, x => x.BanSpecChat) != null; ;
                         userParams["can_spec_chat"] = userSpecChatBlocked ? "0" : "1";
 
-                        userParams["ignored"] = string.Join(",", user.RelalationsByOwner.Where(x => x.Relation == Relation.Ignore).Select(x=>x.Target.Name));
-                        userParams["friends"] = string.Join(",", user.RelalationsByOwner.Where(x => x.Relation == Relation.Friend).Select(x=>x.Target.Name));
-                        
+                        userParams["ignored"] = string.Join(",", user.RelalationsByOwner.Where(x => x.Relation == Relation.Ignore).Select(x => x.Target.Name));
+                        userParams["friends"] = string.Join(",", user.RelalationsByOwner.Where(x => x.Relation == Relation.Friend).Select(x => x.Target.Name));
+
                         if (!p.IsSpectator)
                         {
                             // set valid PW structure attackers
@@ -151,7 +160,7 @@ namespace ZeroKWeb.SpringieInterface
                                 userParams["pwRank"] = (user.AccountRolesByAccountID.Where(
                                             x =>
                                                 !x.RoleType.IsClanOnly &&
-                                                (x.RoleType.RestrictFactionID == null || x.RoleType.RestrictFactionID == user.FactionID)).OrderBy(x=>x.RoleType.DisplayOrder).Select(x => (int?)x.RoleType.DisplayOrder).FirstOrDefault() ?? 999).ToString();
+                                                (x.RoleType.RestrictFactionID == null || x.RoleType.RestrictFactionID == user.FactionID)).OrderBy(x => x.RoleType.DisplayOrder).Select(x => (int?)x.RoleType.DisplayOrder).FirstOrDefault() ?? 999).ToString();
 
 
                                 var allied = user.Faction != null && defender != null && user.Faction != defender &&
@@ -165,10 +174,10 @@ namespace ZeroKWeb.SpringieInterface
                                 userParams["pwInstructions"] = Convert.ToBase64String(Encoding.UTF8.GetBytes(GetPwInstructions(planet, user, db, attacker)));
                             }
 
-                            if (accountIDsWithExtraComms.Contains(user.AccountID)) userParams["extracomm"] = accountIDsWithExtraComms[user.AccountID].ToString();
+                            if (accountIDsWithExtraComms.ContainsKey(user.AccountID)) userParams["extracomm"] = accountIDsWithExtraComms[user.AccountID].ToString();
 
                             var commProfileIDs = new LuaTable();
-                            var userCommandersBanned = Punishment.GetActivePunishment(user.AccountID, null, null, x => x.BanCommanders) != null; 
+                            var userCommandersBanned = Punishment.GetActivePunishment(user.AccountID, null, null, x => x.BanCommanders) != null;
                             if (!userCommandersBanned)
                             {
                                 // set up commander data
@@ -308,7 +317,7 @@ namespace ZeroKWeb.SpringieInterface
             var ipBase = GlobalConst.BaseInfluencePerBattle;
             var ipShips = planet.GetEffectiveShipIpBonus(attacker);
             var ipDefs = planet.GetEffectiveIpDefense();
-            var attackerWinLoseCc = (ipShips + ipBase - ipDefs)*GlobalConst.PlanetWarsAttackerWinLoseCcMultiplier;
+            var attackerWinLoseCc = (ipShips + ipBase - ipDefs) * GlobalConst.PlanetWarsAttackerWinLoseCcMultiplier;
             var attackerLoseKillCc = (ipShips + ipBase - ipDefs) * GlobalConst.PlanetWarsDefenderWinKillCcMultiplier;
 
             attackerWinLoseCc = Math.Max(attackerWinLoseCc, 0);
@@ -364,7 +373,7 @@ namespace ZeroKWeb.SpringieInterface
                     ipBase + ipShips - ipDefs,
                     ipBase,
                     ipShips,
-                    ipDefs, 
+                    ipDefs,
                     attacker?.Shortcut,
                     attackerWinLoseCc);
 


### PR DESCRIPTION
Previously a player could only get 1 extra comm (for a total of 2)
which failed when the other team had more than 2N players.
Now people can get more than 1 extra commander. See #2409