### PR TITLE
User-killed spring does not count as crash

### DIFF
--- a/ChobbyLauncher/Chobbyla.cs
+++ b/ChobbyLauncher/Chobbyla.cs
@@ -263,7 +263,7 @@ namespace ChobbyLauncher
                 {
                     Trace.TraceWarning("Spring exit code is: {0}, {1}", process.ExitCode, isHangKilled ? "user-killed during hang" : "assuming crash");
                 }
-                tcs.TrySetResult(!isCrash);
+                tcs.TrySetResult(!isCrash || isHangKilled);
             };
             process.EnableRaisingEvents = true;
             process.Start();


### PR DESCRIPTION
Generates many false reports that we can't really do anything about.