### PR TITLE
More strict check for clan shortcut (Fix #2344)

### DIFF
--- a/ZkData/Ef/Clan.cs
+++ b/ZkData/Ef/Clan.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace ZkData
 {
@@ -64,7 +65,7 @@ namespace ZkData
 
         public static bool IsShortcutValid(string text)
         {
-            return text.All(Char.IsLetterOrDigit) && text.Length > 0 && text.Length <= 8;
+            return Regex.IsMatch(text, "^[a-zA-Z0-9]{1,8}$");
         }
 
         


### PR DESCRIPTION
Hi,
I've recently tried to create a clan with a Greek character as `shortcut`. Apparently it broke the clan detail page as this `shortcut` is used for a part of the clan background file name.

[Invalid clan page](https://zero-k.info/Clans/Detail/494)

This simple regex should fix the issue (#2344) , unless other characters are required.