### PR TITLE
Remove infolog link from battle detail view

### DIFF
--- a/Zero-K.info/Views/Battles/BattleDetail.cshtml
+++ b/Zero-K.info/Views/Battles/BattleDetail.cshtml
@@ -180,7 +180,6 @@
 @if (Global.IsModerator)
 {
     <div class="admin">
-        Logs: @Html.ActionLink("Logs", "Logs", "Battles", new { id = Model.SpringBattleID }, null) <br />
         <form action="@Url.Action("SetApplicableRatings", new { BattleID = Model.SpringBattleID })" method="post">
             @Html.AntiForgeryToken()
             Counts for competitive skill rating: @Html.CheckBox("MatchMaking", Model.ApplicableRatings.HasFlag(RatingCategoryFlags.MatchMaking)) <br />


### PR DESCRIPTION
This has not worked since 2016. Current state of Springie does not just fail at saving the logs - it doesn't even [try](https://github.com/ZeroK-RTS/Zero-K-Infrastructure/search?q=InfologPathFormat&unscoped_q=InfologPathFormat).