### PR TITLE
Fix Download Mixed Content Warning

### DIFF
--- a/Zero-K.info/Views/Download/DownloadIndex.cshtml
+++ b/Zero-K.info/Views/Download/DownloadIndex.cshtml
@@ -6,7 +6,7 @@
 }
 <div class="fleft width-100" style="padding: 5px;-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;">
     <h1>Downloading Zero-K</h1> <br />
-    <iframe src="http://store.steampowered.com/widget/334920/" width="600" height="190" frameborder="0"></iframe>
+    <iframe src="https://store.steampowered.com/widget/334920/" width="600" height="190" frameborder="0"></iframe>
     @Html.IncludeWiki("Download")
     
 </div>


### PR DESCRIPTION
Prevent download widget showing as a grey rectangle when page viewed over HTTPS, referenced in #2666