### PR TITLE
Up to four users at once searchable in admin chat history

### DIFF
--- a/Zero-K.info/Controllers/LobbyController.cs
+++ b/Zero-K.info/Controllers/LobbyController.cs
@@ -126,6 +126,9 @@ namespace ZeroKWeb.Controllers
             public DateTime? TimeFrom { get; set; }
             public DateTime? TimeTo { get; set; }
             public string User { get; set; }
+            public string User2 { get; set; }
+            public string User3 { get; set; }
+            public string User4 { get; set; }
             public string Text { get; set; }
             public IQueryable<LobbyChatHistory> Data;
         }
@@ -143,7 +146,7 @@ namespace ZeroKWeb.Controllers
             var db = new ZkDataContext();
             var ret = db.LobbyChatHistories.Where(x=>x.SayPlace == model.Place).AsQueryable();
             if (!string.IsNullOrEmpty(model.Channel)) ret = ret.Where(x => x.Target == model.Channel);
-            if (!string.IsNullOrEmpty(model.User)) ret = ret.Where(x => x.User == model.User);
+            if (!string.IsNullOrEmpty(model.User) || !string.IsNullOrEmpty(model.User2) || !string.IsNullOrEmpty(model.User3) || !string.IsNullOrEmpty(model.User4)) ret = ret.Where(x => (x.User == model.User || x.User == model.User2 || x.User == model.User3 || x.User == model.User4));
             if (model.TimeFrom.HasValue) ret = ret.Where(x => x.Time >= model.TimeFrom);
             if (model.TimeTo.HasValue) ret = ret.Where(x => x.Time <= model.TimeTo);
             if (!string.IsNullOrEmpty(model.Text)) ret = ret.Where(x => x.Text.Contains(model.Text));

--- a/Zero-K.info/Controllers/LobbyController.cs
+++ b/Zero-K.info/Controllers/LobbyController.cs
@@ -126,7 +126,7 @@ namespace ZeroKWeb.Controllers
             public DateTime? TimeFrom { get; set; }
             public DateTime? TimeTo { get; set; }
             public string User { get; set; }
-            public string User2 { get; set; }
+            public string User2 { get; set; } // "dumb" multi-user search because the "proper" one doesnt support discord names, only ZKLS
             public string User3 { get; set; }
             public string User4 { get; set; }
             public string Text { get; set; }

--- a/Zero-K.info/Views/Lobby/LobbyChatHistory.cshtml
+++ b/Zero-K.info/Views/Lobby/LobbyChatHistory.cshtml
@@ -55,7 +55,7 @@ var acc = Account.AccountByName(new ZkDataContext(), x.User);
                 <td>Channel</td>
                 <td>@Html.TextBoxFor(x => x.Channel)</td>
             </tr>
-            <tr><td>User</td><td>@Html.TextBoxFor(x => x.User, new { data_autocomplete = Url.Action("UsersNoLink", "Autocomplete"), data_autocomplete_action = "submit" })</td></tr>
+            <tr><td>Users</td><td>@Html.TextBoxFor(x => x.User, new { data_autocomplete = Url.Action("UsersNoLink", "Autocomplete"), data_autocomplete_action = "submit" }) @Html.TextBoxFor(x => x.User2, new { data_autocomplete = Url.Action("UsersNoLink", "Autocomplete"), data_autocomplete_action = "submit" }) @Html.TextBoxFor(x => x.User3, new { data_autocomplete = Url.Action("UsersNoLink", "Autocomplete"), data_autocomplete_action = "submit" }) @Html.TextBoxFor(x => x.User4, new { data_autocomplete = Url.Action("UsersNoLink", "Autocomplete"), data_autocomplete_action = "submit" })</td></tr>
             <tr><td>Time</td><td>@Html.TextBoxFor(x => x.TimeFrom, new { @class = "js_datepicker" }) - @Html.TextBoxFor(x => x.TimeTo, new { @class = "js_datepicker" })</td></tr>
             <tr><td>Text</td><td>@Html.EditorFor(x=>x.Text)</td></tr>
         </table>


### PR DESCRIPTION
This makes it easier to see a conversation in context when chasing down reports.

In theory this would be better done by a mechanism like on the replay search page/rating display, which can accept an arbitrary number of entries. The code which does that would however have to be generalized to accept arbitrary strings (i.e. Discord usernames) rather than just ZK accounts.

Four users will be sufficient for most purposes, this functionality is not visible to end-users anyway and this was far less effort to code. Somebody can generalize it later if they are looking for something to do.