### PR TITLE
Delete maps from Steam build before adding new maps

### DIFF
--- a/AutoRegistrator/SteamDepotGenerator.cs
+++ b/AutoRegistrator/SteamDepotGenerator.cs
@@ -52,6 +52,9 @@ namespace AutoRegistrator
             try
             {
                 Directory.Delete(Path.Combine(targetFolder, "packages"), true);
+                Directory.Delete(Path.Combine(targetFolder, "maps"), true);
+                Directory.Delete(Path.Combine(targetFolder, "pool"), true);
+                Directory.Delete(Path.Combine(targetFolder, "packages"), true);
                 Directory.Delete(Path.Combine(targetFolder, "engine"), true);
                 Directory.Delete(Path.Combine(targetFolder, "games"), true);
                 Directory.Delete(Path.Combine(targetFolder, "rapid"), true);

--- a/AutoRegistrator/SteamDepotGenerator.cs
+++ b/AutoRegistrator/SteamDepotGenerator.cs
@@ -51,7 +51,6 @@ namespace AutoRegistrator
             Utils.CheckPath(targetFolder);
             try
             {
-                Directory.Delete(Path.Combine(targetFolder, "packages"), true);
                 Directory.Delete(Path.Combine(targetFolder, "maps"), true);
                 Directory.Delete(Path.Combine(targetFolder, "pool"), true);
                 Directory.Delete(Path.Combine(targetFolder, "packages"), true);


### PR DESCRIPTION
This is so maps and content doesn't keep adding up in the Steam build, leading to a continuously increasing steam package.