### PR TITLE
Tell Spring games are ZKLS-hosted

### DIFF
--- a/ZkLobbyServer/SpringieInterface/StartSetup.cs
+++ b/ZkLobbyServer/SpringieInterface/StartSetup.cs
@@ -277,6 +277,8 @@ namespace ZeroKWeb.SpringieInterface
                 }
                 ret.ModOptions["commanderTypes"] = commProfiles.ToBase64String();
 
+                ret.ModOptions["isZKLS"] = "1"; // so that clients know e.g. cheats require "!hostsay /x" instead of just "/x" etc.
+
                 // set PW structures
                 if (mode == AutohostMode.Planetwars)
                 {

--- a/ZkLobbyServer/SpringieInterface/StartSetup.cs
+++ b/ZkLobbyServer/SpringieInterface/StartSetup.cs
@@ -277,7 +277,18 @@ namespace ZeroKWeb.SpringieInterface
                 }
                 ret.ModOptions["commanderTypes"] = commProfiles.ToBase64String();
 
-                ret.ModOptions["isZKLS"] = "1"; // so that clients know e.g. cheats require "!hostsay /x" instead of just "/x" etc.
+                /* General-purpose identifier.
+                 * Prefer the more specific ones below when possible */
+                ret.ModOptions["serverType"] = "ZKLS";
+
+                /* Access to commands normally accessible only by the host.
+                 * Lua calls prepend the / on their own, but not the autohost,
+                 * so /say doesn't need it, but the cheat command does */
+                ret.ModOptions["cheatCommandPrefix"] = "say !hostsay /";
+
+                /* The server is listening for SPRINGIE strings (the game can skip those otherwise).
+                 * See https://github.com/ZeroK-RTS/Zero-K-Infrastructure/blob/master/Shared/LobbyClient/DedicatedServer.cs#L317 */
+                ret.ModOptions["sendSpringieData"] = "1";
 
                 // set PW structures
                 if (mode == AutohostMode.Planetwars)


### PR DESCRIPTION
My use-case is that this lets the cheat-menu widget know it has to use `!hostsay /foo` instead of `/foo`.
Another one would be avoiding sending data via `SPRINGIE:FOO` if we know there is no lobbyserver to receive it (awards, modstats, etc).