### PR TITLE
Improve support on distros using 256 color terminals

### DIFF
--- a/SteamRoot/Zero-K_linux64.sh
+++ b/SteamRoot/Zero-K_linux64.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+TERM=xterm
 if [ -f /lib/x86_64-linux-gnu/libc.so.6 ]; then
     ln -fs /lib/x86_64-linux-gnu/libc.so.6 linux64/libc.so
 elif [ -f /lib64/libc.so.6 ]; then


### PR DESCRIPTION
Most Linux installs are now using 256 color terminals. The launcher conflicts with this. Disables 256 color support at launch of script to fix or improve [Chobby#755](https://github.com/ZeroK-RTS/Chobby/issues/755#issuecomment-772746566) (may need to be ported to itch separately)