### PR TITLE
MapDetail links back to all battles for the given map

### DIFF
--- a/Zero-K.info/Views/Maps/Detail.cshtml
+++ b/Zero-K.info/Views/Maps/Detail.cshtml
@@ -98,7 +98,7 @@
     @if (Model.Resource.SpringBattlesByMapResourceID.Any())
     {
         <div class="fleft border">
-            <h3>@Html.ActionLink("Last battles","Index","Battles")</h3>
+            <h3>@Html.ActionLink("Last battles","Index","Battles", new { Map = m.InternalName }, null) </h3>
             @foreach (var b in Model.Resource.SpringBattlesByMapResourceID.OrderByDescending(x => x.SpringBattleID).Take(10))
             {
                 <small>@Html.PrintBattle(b)</small><br />


### PR DESCRIPTION
The map view previously had a Last Battles link that links to the unfiltered Battle index,
but applying a map filter is more useful in this context. Addresses #2792