### PR TITLE
Require one extra vote for resign polls to pass

### DIFF
--- a/ZkLobbyServer/ServerBattle.cs
+++ b/ZkLobbyServer/ServerBattle.cs
@@ -604,7 +604,10 @@ namespace ZkLobbyServer
                 url = $"{GlobalConst.BaseSiteUrl}/Maps/Detail/{(unwrappedCmd as CmdMap).Map.ResourceID}";
                 map = (unwrappedCmd as CmdMap).Map.InternalName;
             }
-            poll = poll ?? new CommandPoll(this, true, true, unwrappedCmd is CmdMap, map, unwrappedCmd is CmdStart);
+
+            var voteMargin = unwrappedCmd is CmdResign ? (unwrappedCmd as CmdResign).RequiredWinMargin : 1;
+
+            poll = poll ?? new CommandPoll(this, true, true, unwrappedCmd is CmdMap, map, unwrappedCmd is CmdStart, voteMargin);
             options.Add(new PollOption()
             {
                 Name = "Yes",

--- a/ZkLobbyServer/autohost/Commands/CmdResign.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdResign.cs
@@ -17,6 +17,10 @@ namespace ZkLobbyServer
         public override string Shortcut => "resign";
         public override AccessType Access => AccessType.IngameVote;
 
+        // We might want different logic to determine the success of a resign vote based on the number of players.
+        // For now just require one more vote than needed for all game sizes, this requires a unanimous vote for up to 4v4 inclusive.
+        public int RequiredWinMargin = 2;
+
         public override BattleCommand Create() => new CmdResign();
 
         public override string Arm(ServerBattle battle, Say e, string arguments = null)


### PR DESCRIPTION
This change makes resign require unanimous approval for small team games (up to 4v4) and makes resign a little harder for large team games, but can be tweaked depending on the exact desired behavior.

Based on feedback in https://zero-k.info/Battles/Detail/1060977

I've sanity checked this to work for 1 and 2 players but haven't fully tested past that, I will do that once I have sign off (it should work fine, but arithmetic errors are embarrassing and testing with 4 accounts locally is a pain)