### PR TITLE
Add sanity check on map ban insertion

### DIFF
--- a/Zero-K.info/Controllers/MapBansController.cs
+++ b/Zero-K.info/Controllers/MapBansController.cs
@@ -58,6 +58,11 @@ namespace ZeroKWeb.Controllers
                 return Content("The same map cannot be banned multiple times.");
             }
 
+            if (resources.Count > GlobalConst.MapBansPerPlayer)
+            {
+                return Content(String.Format("Cannot ban more than {0} maps, got {1} bans.", GlobalConst.MapBansPerPlayer, resources.Count));
+            }
+
             // Fetch the actual resources to sanity check user input and populate IDs for newly selected maps.
             // Filter against current matchmaker to remove any existing bans for a map that has been removed from the MM pool.
             var db = new ZkDataContext();


### PR DESCRIPTION
The check on the maximum map ban length on update was dropped after a refactor, this commit reapplies it. The map banner will
not apply bans past a maximum threshold (currently 75%) so inserting excess bans will not break matchmaker but would give the player a couple of extra bans.