### PR TITLE
TLS 1.2 Update for Launcher

### DIFF
--- a/Shared/PlasmaDownloader/PlasmaDownloader.cs
+++ b/Shared/PlasmaDownloader/PlasmaDownloader.cs
@@ -83,6 +83,7 @@ namespace PlasmaDownloader
             packageDownloader = new PackageDownloader(this);
 
             ServicePointManager.ServerCertificateValidationCallback = (sender, certificate, chain, errors) => true;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12; 
         }
 
         public void Dispose()

--- a/Shared/PlasmaShared/Utils.cs
+++ b/Shared/PlasmaShared/Utils.cs
@@ -654,6 +654,8 @@ namespace ZkData
 
         public static FileResponse<byte[]> DownloadFile(string url, DateTime? ifModifiedSince = null)
         {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             var ms = new MemoryStream();
             var wc = (HttpWebRequest)HttpWebRequest.Create(new Uri(url));
             var ret = new FileResponse<byte[]>();


### PR DESCRIPTION
Fix for 'Could not create SSL/TLS secure channel' to springrts.com on Windows 7 and similar. Reference https://stackoverflow.com/questions/2859790