### PR TITLE
Add battle information to kick log

### DIFF
--- a/ZkLobbyServer/autohost/Commands/CmdKick.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdKick.cs
@@ -88,7 +88,7 @@ namespace ZkLobbyServer
                 string gtype;
                 if (battle.spring.IsRunning)
                 {
-                    gtype = string.Format("game {0} on map {1}", battle.BattleID, battle.MapName);
+                    gtype = string.Format("game on map {0}", battle.MapName);
                     PlasmaShared.BattlePlayerResult res = battle.spring.Context.GetOrAddPlayer(target);
                     isspec = res.IsSpectator;
                 }

--- a/ZkLobbyServer/autohost/Commands/CmdKick.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdKick.cs
@@ -88,7 +88,7 @@ namespace ZkLobbyServer
                 string gtype;
                 if (battle.spring.IsRunning)
                 {
-                    gtype = "game running";
+                    gtype = string.Format("game {0} on map {1}", battle.BattleID, battle.MapName);
                     PlasmaShared.BattlePlayerResult res = battle.spring.Context.GetOrAddPlayer(target);
                     isspec = res.IsSpectator;
                 }


### PR DESCRIPTION
Having the battle id for a kick should make it easier to identify the game where
the kick took place, the map is also provided as a backup and to identify patterns.

This was suggested by Bakuhatsu and I wanted to derust my local infra. I've done a simple sanity check locally.