### PR TITLE
Fix likely typo (Add an 'e')

### DIFF
--- a/ZkLobbyServer/MatchMaker/MatchMaker.cs
+++ b/ZkLobbyServer/MatchMaker/MatchMaker.cs
@@ -114,7 +114,7 @@ namespace ZkLobbyServer
             queueConfigs.Add(new QueueConfig()
             {
                 Name = "1v1",
-                Description = "Play 1v1 with an opponent of similar skill. Games beyond the matching range of '1v1 Narrow' are unranked and hav a bonus for the lower ranked player.",
+                Description = "Play 1v1 with an opponent of similar skill. Games beyond the matching range of '1v1 Narrow' are unranked and have a bonus for the lower ranked player.",
                 UseWinChanceLimit = false,
                 UseHandicap = true,
                 MinSize = 2,


### PR DESCRIPTION
Unless this was explicitly left out for formatting reasons, fix the typo with a missing e in 'have'
And add a new line to be consistent with most other files in Infra.