### PR TITLE
Website: add /Battles/EngineID/x view

### DIFF
--- a/Zero-K.info/Controllers/BattlesController.cs
+++ b/Zero-K.info/Controllers/BattlesController.cs
@@ -15,14 +15,10 @@ namespace ZeroKWeb.Controllers
         //
         // GET: /Battles/
 
-        /// <summary>
-        ///     Returns the page of the <see cref="SpringBattle" /> with the specified ID
-        /// </summary>
-        public ActionResult Detail(int id, bool showWinners = false) {
-            var db = new ZkDataContext();
-            ViewBag.ShowWinners = showWinners;
-            var bat = db.SpringBattles.FirstOrDefault(x => x.SpringBattleID == id);
-            if (bat == null) return Content("No such battle exists");
+        private ActionResult DetailFromSpringBattle(SpringBattle? bat, ZkDataContext db, bool showWinners) {
+            if (bat == null) {
+                return Content("No such battle exists");
+            }
 
             if (bat.ForumThread != null)
             {
@@ -30,9 +26,22 @@ namespace ZeroKWeb.Controllers
                 db.SaveChanges();
             }
 
-            if (Global.AccountID != 0 && !showWinners && bat.SpringBattlePlayers.Any(y => y.AccountID == Global.AccountID && !y.IsSpectator)) ViewBag.ShowWinners = true; // show winners if player played thatbattle
+            if (Global.AccountID != 0 && bat.SpringBattlePlayers.Any(y => y.AccountID == Global.AccountID && !y.IsSpectator)) {
+                ViewBag.ShowWinners = true; // show winners if player played that battle
+            } else {
+                ViewBag.ShowWinners = showWinners;
+            }
 
             return View("BattleDetail", bat);
+        }
+
+        /// <summary>
+        ///     Returns the page of the <see cref="SpringBattle" /> with the specified ID
+        /// </summary>
+        public ActionResult Detail(int id, bool showWinners = false) {
+            var db = new ZkDataContext();
+            var bat = db.SpringBattles.FirstOrDefault(x => x.SpringBattleID == id);
+            return DetailFromSpringBattle(bat, db, showWinners);
         }
         
         /// <summary>
@@ -40,19 +49,8 @@ namespace ZeroKWeb.Controllers
         /// </summary>
         public ActionResult EngineDetail(string id, bool showWinners = false) {
             var db = new ZkDataContext();
-            ViewBag.ShowWinners = showWinners;
             var bat = db.SpringBattles.FirstOrDefault(x => x.EngineGameID == id);
-            if (bat == null) return Content("No such battle exists");
-
-            if (bat.ForumThread != null)
-            {
-                bat.ForumThread.UpdateLastRead(Global.AccountID, false);
-                db.SaveChanges();
-            }
-
-            if (Global.AccountID != 0 && !showWinners && bat.SpringBattlePlayers.Any(y => y.AccountID == Global.AccountID && !y.IsSpectator)) ViewBag.ShowWinners = true; // show winners if player played thatbattle
-
-            return View("BattleDetail", bat);
+            return DetailFromSpringBattle(bat, db, showWinners);
         }
 
         public class BattleSearchModel

--- a/Zero-K.info/Controllers/BattlesController.cs
+++ b/Zero-K.info/Controllers/BattlesController.cs
@@ -15,7 +15,7 @@ namespace ZeroKWeb.Controllers
         //
         // GET: /Battles/
 
-        private ActionResult DetailFromSpringBattle(SpringBattle? bat, ZkDataContext db, bool showWinners) {
+        private ActionResult DetailFromSpringBattle(SpringBattle bat, ZkDataContext db, bool showWinners) {
             if (bat == null) {
                 return Content("No such battle exists");
             }

--- a/Zero-K.info/Controllers/BattlesController.cs
+++ b/Zero-K.info/Controllers/BattlesController.cs
@@ -34,6 +34,26 @@ namespace ZeroKWeb.Controllers
 
             return View("BattleDetail", bat);
         }
+        
+        /// <summary>
+        ///     Returns the page of the <see cref="SpringBattle" /> with the specified engine-generated GameID (not the numerical ZKLS ID)
+        /// </summary>
+        public ActionResult EngineDetail(string id, bool showWinners = false) {
+            var db = new ZkDataContext();
+            ViewBag.ShowWinners = showWinners;
+            var bat = db.SpringBattles.FirstOrDefault(x => x.EngineGameID == id);
+            if (bat == null) return Content("No such battle exists");
+
+            if (bat.ForumThread != null)
+            {
+                bat.ForumThread.UpdateLastRead(Global.AccountID, false);
+                db.SaveChanges();
+            }
+
+            if (Global.AccountID != 0 && !showWinners && bat.SpringBattlePlayers.Any(y => y.AccountID == Global.AccountID && !y.IsSpectator)) ViewBag.ShowWinners = true; // show winners if player played thatbattle
+
+            return View("BattleDetail", bat);
+        }
 
         public class BattleSearchModel
         {


### PR DESCRIPTION
This uses the ID generated by engine at game start, which is available ingame,
as opposed to the regular ZKLS ID which is only available after battle is over.

This way a battle can be identified while it is being played,
for example to generate battle links in ingame reports automatically.