### PR TITLE
`!hostsay` now only for room boss or admins

### DIFF
--- a/ZkLobbyServer/autohost/Commands/BattleCommand.cs
+++ b/ZkLobbyServer/autohost/Commands/BattleCommand.cs
@@ -165,6 +165,16 @@ namespace ZkLobbyServer
                 return RunPermission.None;
             }
 
+            if (Access == AccessType.AdminOrRoomFounder && hasElevatedRights)
+            {
+                return RunPermission.Run;
+            }
+            else if (Access == AccessType.AdminOrRoomFounder)
+            {
+                reason = "This command can only be used by the room founder and moderators.";
+                return RunPermission.None;
+            }
+
             var defPerm = hasElevatedRights ? RunPermission.Run : (isSpectator || isAway || user?.BanVotes == true ? RunPermission.None : RunPermission.Vote);
 
             if (defPerm == RunPermission.None)
@@ -259,6 +269,12 @@ namespace ZkLobbyServer
             /// </summary>
             [Description("When game running, by players, might need a vote. Unavailable to non-admins on autohosts")]
             IngameNotAutohost = 7,
+
+            /// <summary>
+            /// Can be executed ingame/offgame by admins or room founder only
+            /// </summary>
+            [Description("At any time, by admins and room founder only, no vote needed")]
+            AdminOrRoomFounder = 8,
         }
 
 

--- a/ZkLobbyServer/autohost/Commands/CmdHostsay.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdHostsay.cs
@@ -7,7 +7,7 @@ namespace ZkLobbyServer
     {
         public override string Help => "says something as host, useful for !hostsay /nocost etc";
         public override string Shortcut => "hostsay";
-        public override AccessType Access => AccessType.IngameNotAutohost;
+        public override AccessType Access => AccessType.AdminOrRoomFounder;
 
         public override BattleCommand Create() => new CmdHostsay();
 

--- a/ZkLobbyServer/autohost/Commands/CmdPoll.cs
+++ b/ZkLobbyServer/autohost/Commands/CmdPoll.cs
@@ -24,7 +24,12 @@ namespace ZkLobbyServer
             var commandArgs = parts.Length > 1 ? parts[1] : null;
             InternalCommand = battle.GetCommandByName(commandName);
             string reason;
-            if (InternalCommand.GetRunPermissions(battle, e.User, out reason) >= RunPermission.Vote && InternalCommand.Access != AccessType.NoCheck && InternalCommand.Access != AccessType.Admin && !(InternalCommand.Access == AccessType.NotIngameNotAutohost && battle.IsAutohost))
+
+            if (InternalCommand.GetRunPermissions(battle, e.User, out reason) >= RunPermission.Vote
+            && InternalCommand.Access != AccessType.NoCheck
+            && InternalCommand.Access != AccessType.Admin
+            && InternalCommand.Access != AccessType.AdminOrRoomFounder
+            && !(InternalCommand.Access == AccessType.NotIngameNotAutohost && battle.IsAutohost))
             {
                 return InternalCommand.Arm(battle, e, commandArgs);
             }


### PR DESCRIPTION
Prevents people from communicating in spec-muted FFA via `!poll hostsay XYZ is making a nuke` and such.