### PR TITLE
Drop avatarwiki from the forum formatting link

### DIFF
--- a/Zero-K.info/Views/Forum/NewPost.cshtml
+++ b/Zero-K.info/Views/Forum/NewPost.cshtml
@@ -50,7 +50,7 @@ else
     {
         <input type="checkbox" name="isMinorEdit" value="true"/><span>Minor edit (does not bump thread)</span>
     }
-    <a href="~/Wiki/formatting" target="_blank" style="float: right">Forum and Wiki formatting guide</a>
+    <a href="~/Wiki/formatting" target="_blank" style="float: right">Forum formatting guide</a>
 </form>
 
 @if (Model.LastPosts != null && Model.CurrentThread != null)


### PR DESCRIPTION
Doesn't apply to mediawiki and avatarwiki is discouraged.