### PR TITLE
Run additional WHR iterations on initialization

### DIFF
--- a/ZkData/Ef/WHR/WholeHistoryRating.cs
+++ b/ZkData/Ef/WHR/WholeHistoryRating.cs
@@ -323,7 +323,7 @@ namespace Ratings
                     updateAction = (() =>
                     {
                         Trace.TraceInformation("Initializing WHR " + category + " ratings for " + battlesRegistered + " battles, this will take some time..");
-                        runIterations(75);
+                        runIterations(150);
                         UpdateRankings(players.Values);
                         completelyInitialized = true;
                         cachedDbRatings.Clear();


### PR DESCRIPTION
This will prolong initialization time by around 7-8 minutes based on timings from a restart on 2022-09-01

It should alleviate issues caused by non converged ratings after restart.