### PR TITLE
Set the "connecting to: xyz" message on early engine load

### DIFF
--- a/Shared/LobbyClient/ScriptGenerator.cs
+++ b/Shared/LobbyClient/ScriptGenerator.cs
@@ -60,6 +60,9 @@ namespace LobbyClient
                 // send desync to server
                 script.AppendFormat("  DumpGameStateOnDesync=1;\n");
 
+                // set the "connecting to: xyz" message during early engine load
+                script.AppendFormat("  ShowServerName={0};\n", context.LobbyStartContext.Title.Replace(';', ' '));
+
                 if (loopbackListenPort >0) script.AppendFormat("  AutohostPort={0};\n", loopbackListenPort);
                 script.AppendLine();
                 script.AppendFormat("  HostIP={0};\n", context.IpAddress);


### PR DESCRIPTION
Right now it says the IP:port of the server, like

> Connecting to: [12.34.56.78]:12345

This looks scary, apparently some streamers think it's their own IP that just got broadcast public. The patch changes it to room title, like

> Connecting to: Teams All Welcome

It only works on fresh engines but should be harmless otherwise. See https://github.com/beyond-all-reason/spring/pull/1282