### PR TITLE
Improve ChobbyLauncher crash reporting

### DIFF
--- a/ChobbyLauncher/ChobbylaLocalListener.cs
+++ b/ChobbyLauncher/ChobbylaLocalListener.cs
@@ -656,7 +656,7 @@ namespace ChobbyLauncher
                             StartScriptContent = args.StartScriptContent
                         });
                         
-                        CrashReportHelper.CheckAndReportErrors(logs.ToString(), isOk, "Externally launched spring crashed with code " + process.ExitCode, null, args.Engine);
+                        CrashReportHelper.CheckAndReportErrors(logs.ToString(), isOk, paths, "Externally launched spring crashed with code " + process.ExitCode, null, args.Engine);
                     };
                     process.EnableRaisingEvents = true;
                     process.Start();

--- a/ChobbyLauncher/Program.cs
+++ b/ChobbyLauncher/Program.cs
@@ -168,7 +168,7 @@ namespace ChobbyLauncher
             logWriter.Flush();
             var logStr = logSb.ToString();
 
-            CrashReportHelper.CheckAndReportErrors(logStr, springRunOk, chobbyla.BugReportTitle, chobbyla.BugReportDescription, chobbyla.engine);
+            CrashReportHelper.CheckAndReportErrors(logStr, springRunOk, chobbyla.paths, chobbyla.BugReportTitle, chobbyla.BugReportDescription, chobbyla.engine);
         }
 
         static async Task<bool> PrepareWithoutGui(Chobbyla chobbyla)


### PR DESCRIPTION
The primary purpose of these improvements is to collect more desync data.

See this example issue: https://github.com/Mankarse/Zero-K-Debug/issues/34

I have split the changes into 5 commits, ordered from least to most controversial.

The first three commits are uncontroversial improvements.
The remaining two commits might be controversial, because they use GitHub in an unusual way.

**1) Updated Octokit.net to the latest version**
This contains a necessary bugfix. You should apply this, even if you do nothing else with my Pull Request.

**2) Improve the algorithm in CrashReportHelper.Truncate**
The new algorithm is required for the later commits to work.
It is still valuable even if they later commits are not used, because it is much faster.
The only downside is that its implementation is much larger.

**3) Improve parsing of infolog_full.txt**
Splits infolog by game, and extracts GameID, Desync locations, GameState file names.
Includes GameState file names in the Issue description (if they are relevant).

**4) Use Issue Labels to link desync issues arising from the same game**

Adds "GameStateFor-{gameID}" and "HasDesyncGameState" labels whenever a crash report includes GameState for a desync.

Add "HasLinkedDesyncIssue" label when there is an Issue with a matching "GameStateFor-{gameID}" label.

Adds links to existing Issues to the description of the new Issue.

This will create an unbounded number of Labels (one for each gameID).

Please suggest better names for these Labels, if you have any ideas.

**5) Upload files to GitHub**
This works by creating a "Release" for every 250 issues, and then uploading the files to that release.

The main risk of changes 4 and 5 is that they increase the chance that the ZeroK-RTS/CrashReports will hit
usage limits.

I am not aware of any documented limits that will be exceeded, but it is possible that GitHub will not like the unusual way that CrashReports will be being used.