### PR TITLE
Push commit discord message: add horizontal lines

### DIFF
--- a/Zero-K.info/Controllers/GithubController.cs
+++ b/Zero-K.info/Controllers/GithubController.cs
@@ -64,7 +64,7 @@ namespace ZeroKWeb.Controllers
                     dynamic commits = payload.commits;
                     foreach (dynamic commit in commits)
                     {
-                        sb.AppendFormat("\n {0} <{1}>", commit.message, commit.url);
+                        sb.AppendFormat("\n~~                    ~~\n{0} <{1}>", commit.message, commit.url);
                         count++;
                     }
                     if (count > 0) text = $"[{payload.repository.name}] {payload.sender.login} has pushed {count} commits: {sb}";


### PR DESCRIPTION
To better delimit adjacent commits. Right now it looks like this, where the intuitive reading is for the "red" grouping to be a single commit. But in reality it's the unintuitive "green" grouping:
![image](https://github.com/user-attachments/assets/218977da-91b6-4312-b51e-43b4a2e0e8b2)


Discord doesn't have the `<hr>` tag so use strikethrough on spaces to get a horizontal line.