### PR TITLE
Revert System.Runtime.CompilerServices.Unsafe to 5.0.0.0.

### DIFF
--- a/Zero-K.info/Web.config
+++ b/Zero-K.info/Web.config
@@ -147,7 +147,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />


### PR DESCRIPTION
Every other config uses either 5.0.0.0 or 4.0.6.0, and this fixes local builds. Might break #3002.