### PR TITLE
Prevent players in waitlist from being considered in votes #2780

### DIFF
--- a/ZkLobbyServer/ServerBattle.cs
+++ b/ZkLobbyServer/ServerBattle.cs
@@ -84,7 +84,7 @@ namespace ZkLobbyServer
         public bool IsDefaultGame { get; private set; } = true;
         public bool IsCbalEnabled { get; private set; } = true;
 
-        public bool TimeQueueEnabled = true;//> DynamicConfig.Instance.TimeQueueEnabled && true;//(Mode == AutohostMode.Teams || Mode == AutohostMode.Game1v1 || Mode == AutohostMode.GameFFA);
+        public override bool TimeQueueEnabled => DynamicConfig.Instance.TimeQueueEnabled && (Mode == AutohostMode.Teams || Mode == AutohostMode.Game1v1 || Mode == AutohostMode.GameFFA);
 
         public MapSupportLevel MinimalMapSupportLevelAutohost { get; protected set; } = MapSupportLevel.Featured;
 
@@ -557,9 +557,7 @@ namespace ZkLobbyServer
                 allowedPlayers = context.Players.Where(x => !x.IsSpectator).Count() & ~0x1;
             }
             var waitlist = context.Players.Where(x => !x.IsSpectator).OrderBy(x => x.QueueOrder).Skip(allowedPlayers).ToList();
-            Debug.WriteLine(username);
             var isInWaitlist = waitlist.Exists(x => x.Name == username);
-            Debug.WriteLine(isInWaitlist);
             return isInWaitlist;
             
         }
@@ -576,7 +574,6 @@ namespace ZkLobbyServer
                 {
                     allowedPlayers = context.Players.Where(x => !x.IsSpectator).Count() & ~0x1;
                 }
-                //THIS LINE IS THE
                 foreach (var plr in context.Players.Where(x=>!x.IsSpectator).OrderBy(x => x.QueueOrder).Skip(allowedPlayers))
                 {
                     plr.IsSpectator = true;

--- a/ZkLobbyServer/ServerBattle.cs
+++ b/ZkLobbyServer/ServerBattle.cs
@@ -84,7 +84,7 @@ namespace ZkLobbyServer
         public bool IsDefaultGame { get; private set; } = true;
         public bool IsCbalEnabled { get; private set; } = true;
 
-        public override bool TimeQueueEnabled => DynamicConfig.Instance.TimeQueueEnabled && (Mode == AutohostMode.Teams || Mode == AutohostMode.Game1v1 || Mode == AutohostMode.GameFFA);
+        public bool TimeQueueEnabled = true;//> DynamicConfig.Instance.TimeQueueEnabled && true;//(Mode == AutohostMode.Teams || Mode == AutohostMode.Game1v1 || Mode == AutohostMode.GameFFA);
 
         public MapSupportLevel MinimalMapSupportLevelAutohost { get; protected set; } = MapSupportLevel.Featured;
 
@@ -546,6 +546,24 @@ namespace ZkLobbyServer
             if (server.ConnectedUsers.TryGetValue(name, out usr)) await usr.Process(new UpdateUserBattleStatus() { Name = usr.Name, IsSpectator = true });
         }
 
+        public bool IsInWaitlist(string username)
+        {
+            
+            if (!TimeQueueEnabled) return false;
+            var context = GetContext();
+            int allowedPlayers = MaxPlayers;
+            if (context.Players.Where(x => !x.IsSpectator).Count() <= MaxEvenPlayers)
+            {
+                allowedPlayers = context.Players.Where(x => !x.IsSpectator).Count() & ~0x1;
+            }
+            var waitlist = context.Players.Where(x => !x.IsSpectator).OrderBy(x => x.QueueOrder).Skip(allowedPlayers).ToList();
+            Debug.WriteLine(username);
+            var isInWaitlist = waitlist.Exists(x => x.Name == username);
+            Debug.WriteLine(isInWaitlist);
+            return isInWaitlist;
+            
+        }
+
 
         public async Task<bool> StartGame()
         {
@@ -558,6 +576,7 @@ namespace ZkLobbyServer
                 {
                     allowedPlayers = context.Players.Where(x => !x.IsSpectator).Count() & ~0x1;
                 }
+                //THIS LINE IS THE
                 foreach (var plr in context.Players.Where(x=>!x.IsSpectator).OrderBy(x => x.QueueOrder).Skip(allowedPlayers))
                 {
                     plr.IsSpectator = true;

--- a/ZkLobbyServer/autohost/Commands/BattleCommand.cs
+++ b/ZkLobbyServer/autohost/Commands/BattleCommand.cs
@@ -99,6 +99,8 @@ namespace ZkLobbyServer
             return isSpectator;
         }
 
+
+
         /// <summary>
         /// Determines the required margin for a majority vote to pass
         /// </summary>
@@ -145,6 +147,7 @@ namespace ZkLobbyServer
             var s = battle.spring;
             bool isSpectator = IsSpectator(battle, userName, ubs);
             bool isAway = user?.IsAway == true;
+            bool isInWaitlist = battle.IsInWaitlist(userName);
             int count = 0;
             if (s.IsRunning)
             {
@@ -175,13 +178,14 @@ namespace ZkLobbyServer
                 return RunPermission.None;
             }
 
-            var defPerm = hasElevatedRights ? RunPermission.Run : (isSpectator || isAway || user?.BanVotes == true ? RunPermission.None : RunPermission.Vote);
+            var defPerm = hasElevatedRights ? RunPermission.Run : (isInWaitlist || isSpectator || isAway || user?.BanVotes == true ? RunPermission.None : RunPermission.Vote);
 
             if (defPerm == RunPermission.None)
             {
                 reason = "This command can't be executed by spectators. Join the game to use this command.";
                 if (isAway) reason = "You can't vote while being AFK.";
                 if (user?.BanVotes == true) reason = "You have been banned from using votes. Check your user page for details.";
+                if (isInWaitlist) reason = "You can't vote if you are in the waitlist.";
                 return RunPermission.None;
             }
             if (defPerm == RunPermission.Vote && count<=1) defPerm = RunPermission.Run;


### PR DESCRIPTION
`Battlecommand.GetRunPermissions()` will now check if the player is in the waitlist, before considering the player as part of a vote.

 I added a function in `ServerBattle`, `public bool ServerBattle.IsInWaitlist(username)`, that takes in a player's username, and returns a boolean to check whether or not they are in the waitlist.

The logic in this function is basically identical to the first few lines in `ServerBattle.StartGame()` . As far as I can tell, this is how you determine if a player is in the waitlist. 

If a player is considered part of the waitlist, they will not be able to vote, and the bot will specify that players in the waitlist should not be able to vote.

Some thoughts / concerns:
- Not sure if there should be any difference between spectator and waitlisted specified in the messages.

- Not sure if im missing any logic or edge cases in `IsInWaitlist()`. It seems to be fine, since its exactly the code that determines what players actually play or not when a game is started, but still. 

- Not sure if its safe to call `battle.IsInWaitlist()`; I dont know if battle can be null when a vote is caused, and if that will cause some crash.

