### PR TITLE
Unsupported lobby warning: only print if login successful

### DIFF
--- a/ZkLobbyServer/LoginChecker.cs
+++ b/ZkLobbyServer/LoginChecker.cs
@@ -153,11 +153,6 @@ namespace ZkLobbyServer
                     LogIP(db, acc, ip);
                     LogUserID(db, acc, userID, installID);
 
-                    if (String.IsNullOrEmpty(installID) && !acc.HasVpnException)
-                    {
-                        await server.GhostChanSay(GlobalConst.ModeratorChannel, string.Format("{0} just logged in with an unsupported lobby https://zero-k.info/Users/AdminUserDetail/{1}", acc.Name, acc.AccountID));
-                    }
-
                     db.SaveChanges();
 
                     ret.LoginResponse.SessionToken = Guid.NewGuid().ToString(); // create session token
@@ -174,6 +169,11 @@ namespace ZkLobbyServer
                                 installID);
 
                     if (!acc.HasVpnException && GlobalConst.VpnCheckEnabled && !acc.SteamID.HasValue) if (HasVpn(ip, acc, db)) return BlockLogin("Connection using proxy or VPN is not allowed! (You can ask for exception)", acc, ip, userID, installID);
+
+                    if (String.IsNullOrEmpty(installID) && !acc.HasVpnException)
+                    {
+                        await server.GhostChanSay(GlobalConst.ModeratorChannel, string.Format("{0} just logged in with an unsupported lobby https://zero-k.info/Users/AdminUserDetail/{1}", acc.Name, acc.AccountID));
+                    }
 
                     return ret;
                 }


### PR DESCRIPTION
Not printed when a banned account tries to login.